### PR TITLE
Negative value support for bar rule set

### DIFF
--- a/src/js/oncoprintlegendrenderer.js
+++ b/src/js/oncoprintlegendrenderer.js
@@ -119,40 +119,51 @@ var OncoprintLegendView = (function() {
 		root.appendChild(text_node);
 	    }
 	} else if (config.type === 'number') {
-	    var num_decimal_digits = 2;
-	    var display_range = config.range.map(function(x) {
-		var num_digit_multiplier = Math.pow(10, num_decimal_digits);
-		return Math.round(x * num_digit_multiplier) / num_digit_multiplier;
-	    });
-	    root.appendChild(svgfactory.text(display_range[0], 0, 0, 12, 'Arial', 'normal'));
-	    root.appendChild(svgfactory.text(display_range[1], 50, 0, 12, 'Arial', 'normal'));
-	    var mesh = 100;
-	    var points = [];
-	    points.push([5, 20]);
-	    for (var i=0; i<mesh; i++) {
-		var t = i/mesh;
-		var h = config.interpFn((1-t)*config.range[0] + t*config.range[1]);
-		var height = 20*h;
-		points.push([5 + 40*i/mesh, 20-height]);
-	    }
-	    points.push([45, 20]);
-	    root.appendChild(svgfactory.path(points, config.color, config.color));
-	} else if (config.type === 'gradient') {
-	    var num_decimal_digits = 2;
-	    var display_range = config.range.map(function(x) {
-		var num_digit_multiplier = Math.pow(10, num_decimal_digits);
-		return Math.round(x * num_digit_multiplier) / num_digit_multiplier;
-	    });
-	    var gradient = svgfactory.gradient(config.colorFn);
-	    var gradient_id = gradient.getAttribute("id");
-	    target_defs.appendChild(gradient);
-	    root.appendChild(svgfactory.text(display_range[0], 0, 0, 12, 'Arial', 'normal'));
-	    root.appendChild(svgfactory.text(display_range[1], 120, 0, 12, 'Arial', 'normal'));
-	    root.appendChild(svgfactory.rect(30,0,60,20,"url(#"+gradient_id+")"));
+        var num_decimal_digits = 2;
+        var display_range = config.range.map(function (x) {
+            var num_digit_multiplier = Math.pow(10, num_decimal_digits);
+            return Math.round(x * num_digit_multiplier) / num_digit_multiplier;
+        });
+        root.appendChild(svgfactory.text(display_range[0], 0, 0, 12, 'Arial', 'normal'));
+        root.appendChild(svgfactory.text(display_range[1], 50, 0, 12, 'Arial', 'normal'));
+        var mesh = 100;
+        var points = [];
+        var linear_gradient = svgfactory.linearGradient();
+        if (config.range_type === 'NON_POSITIVE') {
+            linear_gradient.appendChild(svgfactory.stop(100, config.negative_color));
+        } else if (config.range_type === 'UNSIGNED') {
+            linear_gradient.appendChild(svgfactory.stop(100, config.positive_color));
+        } else {
+        	var offset = Math.abs(display_range[0]) / (Math.abs(display_range[0]) + display_range[1]) * 100;
+            linear_gradient.appendChild(svgfactory.stop(offset, config.negative_color));
+            linear_gradient.appendChild(svgfactory.stop(offset, config.positive_color));
+        }
+        root.appendChild(linear_gradient);
+        points.push([5, 20]);
+        for (var i = 0; i < mesh; i++) {
+            var t = i / mesh;
+            var h = config.interpFn((1 - t) * config.range[0] + t * config.range[1]);
+            var height = 20 * h;
+            points.push([5 + 40 * i / mesh, 20 - height]);
+        }
+        points.push([45, 20]);
+        root.appendChild(svgfactory.path(points, null, null, linear_gradient));
+    } else if (config.type === 'gradient') {
+        var num_decimal_digits = 2;
+        var display_range = config.range.map(function(x) {
+            var num_digit_multiplier = Math.pow(10, num_decimal_digits);
+            return Math.round(x * num_digit_multiplier) / num_digit_multiplier;
+        });
+        var gradient = svgfactory.gradient(config.colorFn);
+        var gradient_id = gradient.getAttribute("id");
+        target_defs.appendChild(gradient);
+        root.appendChild(svgfactory.text(display_range[0], 0, 0, 12, 'Arial', 'normal'));
+        root.appendChild(svgfactory.text(display_range[1], 120, 0, 12, 'Arial', 'normal'));
+        root.appendChild(svgfactory.rect(30,0,60,20,"url(#"+gradient_id+")"));
 	}
 	return root;
     };
-    
+
     OncoprintLegendView.prototype.setWidth = function(w, model) {
 	this.width = w;
 	renderLegend(this, model);

--- a/src/js/oncoprinttrackoptionsview.js
+++ b/src/js/oncoprinttrackoptionsview.js
@@ -125,7 +125,7 @@ var OncoprintTrackOptionsView = (function () {
 	var $div, $img, $dropdown;
 	var top = model.getZoomedTrackTops(track_id);
 	$div = $('<div>').appendTo(view.$buttons_ctr).css({'position': 'absolute', 'left': '0px', 'top': top + 'px'});
-	$img = $('<img/>').appendTo($div).attr({'src': 'img/menudots.svg', 'width': view.img_size, 'height': view.img_size}).css({'float': 'left', 'cursor': 'pointer', 'border': '1px solid rgba(125,125,125,0)'});
+	$img = $('<img/>').appendTo($div).attr({'src': 'images/menudots.svg', 'width': view.img_size, 'height': view.img_size}).css({'float': 'left', 'cursor': 'pointer', 'border': '1px solid rgba(125,125,125,0)'});
 	$dropdown = $('<ul>').appendTo(view.$dropdown_ctr).css({'position':'absolute', 'width': 120, 'display': 'none', 'list-style-type': 'none', 'padding-left': '6', 'padding-right': '6', 'float': 'right', 'background-color': 'rgb(255,255,255)',
 								'left':'0px', 'top': top + view.img_size + 'px'});
 	view.track_options_$elts[track_id] = {'$div': $div, '$img': $img, '$dropdown': $dropdown};

--- a/src/js/svgfactory.js
+++ b/src/js/svgfactory.js
@@ -96,22 +96,36 @@ module.exports = {
     bgrect: function(width, height, fill) {
 	return makeSVGElement('rect', {'width':width, 'height':height, 'fill':fill});
     },
-    path: function(points, stroke, fill) {
+    path: function(points, stroke, fill, linearGradient) {
 	points = points.map(function(pt) { return pt.join(","); });
 	points[0] = 'M'+points[0];
 	for (var i=1; i<points.length; i++) {
 	    points[i] = 'L'+points[i];
 	}
-	stroke = extractColor(stroke);
-	fill = extractColor(fill);
+
+	if (!linearGradient) {
+        stroke = extractColor(stroke);
+        fill = extractColor(fill);
+	}
+
 	return makeSVGElement('path', {
 	    'd': points.join(" "),
-	    'stroke': stroke.rgb,
-	    'stroke-opacity': stroke.opacity,
-	    'fill': fill.rgb,
-	    'fill-opacity': fill.opacity
+	    'stroke': linearGradient ? 'url(#'+linearGradient.getAttribute('id')+')' : stroke.rgb,
+	    'stroke-opacity': linearGradient ? 0 : stroke.opacity,
+	    'fill': linearGradient ? 'url(#'+linearGradient.getAttribute('id')+')' : fill.rgb,
+	    'fill-opacity': linearGradient ? 1 : fill.opacity
 	});
     },
+    stop: function (offset, stop_color, stop_opacity) {
+		return makeSVGElement('stop', {
+			'offset': offset + '%',
+			'stop-color': stop_color,
+			'stop-opacity': stop_opacity
+		});
+	},
+	linearGradient: function () {
+        return makeSVGElement('linearGradient', {'id': 'linearGradient'+gradientId()});
+	},
     defs: function() {
 	return makeSVGElement('defs');
     },
@@ -125,11 +139,9 @@ module.exports = {
 	});
 	for (var i=0; i<=100; i++) {
 	    var color = extractColor(colorFn(i/100));
-	    gradient.appendChild(makeSVGElement('stop', {
-		'offset': i + '%',
-		'stop-color':color.rgb,
-		'stop-opacity': color.opacity
-	    }));
+	    gradient.appendChild(
+	    	this.stop(i + '%', color.rgb, color.opacity)
+		);
 	}
 	return gradient;
     }


### PR DESCRIPTION
This pull request is to add support of negative values when displaying clinical track in the OncoPrint tab. These changes will handle three possibilities:

### Data consists of non negative values
===
<img width="791" alt="screen shot 2017-08-01 at 22 03 41" src="https://user-images.githubusercontent.com/2835281/29035764-1ba8b3e0-7b9d-11e7-9394-301c9179531c.png">


### Data consists of non positive values
===
<img width="791" alt="screen shot 2017-08-01 at 22 04 13" src="https://user-images.githubusercontent.com/2835281/29035801-3bf95974-7b9d-11e7-981c-961bcd76ce01.png">


### Data consists of all type of values
===
<img width="798" alt="screen shot 2017-08-01 at 22 03 14" src="https://user-images.githubusercontent.com/2835281/29035808-43b9fcea-7b9d-11e7-9f72-941de0ebba22.png">

 