### PR TITLE
Negative value support for bar rule set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ dist
 .DS_Store
 src/.DS_Store
 test/.DS_Store
+
+# IntelliJ IDEA
+.idea/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,11 @@
 var gulp = require('gulp');
 var shell = require('gulp-shell');
 
-gulp.task('default', shell.task(['browserify src/js/main.js -o dist/oncoprint-bundle.js',
-				'cp src/css/* dist/',
-				'cp src/img/* dist/',
-				]));
+gulp.task('default', shell.task([
+    'mkdir -p dist/',
+    'browserify src/js/main.js -o dist/oncoprint-bundle.js',
+    'cp src/css/* dist/',
+    'cp src/img/* dist/'
+]));
+
+gulp.task('test', shell.task(['browserify test.js -o oncoprint-test-bundle.js']));

--- a/index.html
+++ b/index.html
@@ -1,0 +1,9 @@
+<html>
+	<head>
+		<script type='text/javascript' src='https://code.jquery.com/jquery-1.11.3.js'></script>
+		<script type='text/javascript' src='oncoprint-test-bundle.js'></script>
+	</head>
+	<body>
+            <div id="oncoprint"></div>
+	</body>
+</html>

--- a/src/js/oncoprintlegendrenderer.js
+++ b/src/js/oncoprintlegendrenderer.js
@@ -119,40 +119,51 @@ var OncoprintLegendView = (function() {
 		root.appendChild(text_node);
 	    }
 	} else if (config.type === 'number') {
-	    var num_decimal_digits = 2;
-	    var display_range = config.range.map(function(x) {
-		var num_digit_multiplier = Math.pow(10, num_decimal_digits);
-		return Math.round(x * num_digit_multiplier) / num_digit_multiplier;
-	    });
-	    root.appendChild(svgfactory.text(display_range[0], 0, 0, 12, 'Arial', 'normal'));
-	    root.appendChild(svgfactory.text(display_range[1], 50, 0, 12, 'Arial', 'normal'));
-	    var mesh = 100;
-	    var points = [];
-	    points.push([5, 20]);
-	    for (var i=0; i<mesh; i++) {
-		var t = i/mesh;
-		var h = config.interpFn((1-t)*config.range[0] + t*config.range[1]);
-		var height = 20*h;
-		points.push([5 + 40*i/mesh, 20-height]);
-	    }
-	    points.push([45, 20]);
-	    root.appendChild(svgfactory.path(points, config.color, config.color));
-	} else if (config.type === 'gradient') {
-	    var num_decimal_digits = 2;
-	    var display_range = config.range.map(function(x) {
-		var num_digit_multiplier = Math.pow(10, num_decimal_digits);
-		return Math.round(x * num_digit_multiplier) / num_digit_multiplier;
-	    });
-	    var gradient = svgfactory.gradient(config.colorFn);
-	    var gradient_id = gradient.getAttribute("id");
-	    target_defs.appendChild(gradient);
-	    root.appendChild(svgfactory.text(display_range[0], 0, 0, 12, 'Arial', 'normal'));
-	    root.appendChild(svgfactory.text(display_range[1], 120, 0, 12, 'Arial', 'normal'));
-	    root.appendChild(svgfactory.rect(30,0,60,20,"url(#"+gradient_id+")"));
+        var num_decimal_digits = 2;
+        var display_range = config.range.map(function (x) {
+            var num_digit_multiplier = Math.pow(10, num_decimal_digits);
+            return Math.round(x * num_digit_multiplier) / num_digit_multiplier;
+        });
+        root.appendChild(svgfactory.text(display_range[0], 0, 0, 12, 'Arial', 'normal'));
+        root.appendChild(svgfactory.text(display_range[1], 50, 0, 12, 'Arial', 'normal'));
+        var mesh = 100;
+        var points = [];
+        var linear_gradient = svgfactory.linearGradient();
+        if (config.range_type === 'NON_POSITIVE') {
+            linear_gradient.appendChild(svgfactory.stop(100, config.negative_color));
+        } else if (config.range_type === 'NON_NEGATIVE') {
+            linear_gradient.appendChild(svgfactory.stop(100, config.positive_color));
+        } else if (config.range_type === 'ALL') {
+        	var offset = Math.abs(display_range[0]) / (Math.abs(display_range[0]) + display_range[1]) * 100;
+            linear_gradient.appendChild(svgfactory.stop(offset, config.negative_color));
+            linear_gradient.appendChild(svgfactory.stop(offset, config.positive_color));
+        }
+        root.appendChild(linear_gradient);
+        points.push([5, 20]);
+        for (var i = 0; i < mesh; i++) {
+            var t = i / mesh;
+            var h = config.interpFn((1 - t) * config.range[0] + t * config.range[1]);
+            var height = 20 * h;
+            points.push([5 + 40 * i / mesh, 20 - height]);
+        }
+        points.push([45, 20]);
+        root.appendChild(svgfactory.path(points, null, null, linear_gradient));
+    } else if (config.type === 'gradient') {
+        var num_decimal_digits = 2;
+        var display_range = config.range.map(function(x) {
+            var num_digit_multiplier = Math.pow(10, num_decimal_digits);
+            return Math.round(x * num_digit_multiplier) / num_digit_multiplier;
+        });
+        var gradient = svgfactory.gradient(config.colorFn);
+        var gradient_id = gradient.getAttribute("id");
+        target_defs.appendChild(gradient);
+        root.appendChild(svgfactory.text(display_range[0], 0, 0, 12, 'Arial', 'normal'));
+        root.appendChild(svgfactory.text(display_range[1], 120, 0, 12, 'Arial', 'normal'));
+        root.appendChild(svgfactory.rect(30,0,60,20,"url(#"+gradient_id+")"));
 	}
 	return root;
     };
-    
+
     OncoprintLegendView.prototype.setWidth = function(w, model) {
 	this.width = w;
 	renderLegend(this, model);

--- a/src/js/oncoprintruleset.js
+++ b/src/js/oncoprintruleset.js
@@ -70,7 +70,7 @@ function makeUniqueColorGetter(init_used_colors) {
 	}
 	used_colors[next_color] = true;
 	index += 1;
-	
+
 	return next_color;
     };
 };
@@ -124,7 +124,7 @@ var colorToHex = function(str) {
 	}
 	return '#' + r + g + b;
     }
-    
+
     var rgb_match = str.match(/^[\s]*rgb\([\s]*([0-9]+)[\s]*,[\s]*([0-9]+)[\s]*,[\s]*([0-9]+)[\s]*\)[\s]*$/);
     if (rgb_match && rgb_match.length === 4) {
 	r = parseInt(rgb_match[1]).toString(16);
@@ -141,7 +141,7 @@ var colorToHex = function(str) {
 	}
 	return '#' + r + g + b;
     }
-    
+
     return str;
 };
 
@@ -404,14 +404,14 @@ var CategoricalRuleSet = (function () {
 	 * - categoryToColor
 	 */
 	LookupRuleSet.call(this, params);
-	
+
 	this.addRule(NA_STRING, true, {
 	    shapes: makeNAShapes(params.na_z || 1000),
 	    legend_label: NA_LABEL,
 	    exclude_from_legend: false,
 	    legend_config: {'type': 'rule', 'target': {'na': true}}
 	});
-	
+
 	this.category_key = params.category_key;
 	this.category_to_color = ifndef(params.category_to_color, {});
 	this.getUnusedColor = makeUniqueColorGetter(objectValues(this.category_to_color).map(colorToHex));
@@ -449,7 +449,7 @@ var CategoricalRuleSet = (function () {
 	    var category = data[i][this.category_key];
 	    if (!this.category_to_color.hasOwnProperty(category)) {
 		var color = this.getUnusedColor(this);
-		
+
 		this.category_to_color[category] = color;
 		addCategoryRule(this, category, color);
 	    }
@@ -469,35 +469,47 @@ var LinearInterpRuleSet = (function () {
 	 * - value_range
 	 */
 	ConditionRuleSet.call(this, params);
+
 	this.value_key = params.value_key;
 	this.value_range = params.value_range;
 	this.log_scale = params.log_scale; // boolean
-	this.inferred_value_range;
+
+	this.rangeTypes = {
+		'ALL': 'ALL',                   // all values positive, negative and zero
+		'NON_NEGATIVE': 'NON_NEGATIVE', // value range all positive values inclusive zero (0)
+		'NON_POSITIVE': 'NON_POSITIVE'  // value range all negative values inclusive zero (0)
+	};
 
 	this.makeInterpFn = function () {
 	    var range = this.getEffectiveValueRange();
+	    var rangeType = this.getValueRangeType();
+	    var rangeTypes = this.rangeTypes;
 
 	    if (this.log_scale) {
-		var shift_to_make_pos = Math.abs(range[0]) + 1;
-		var log_range = Math.log(range[1] + shift_to_make_pos) - Math.log(range[0] + shift_to_make_pos);
-		var log_range_lower = Math.log(range[0] + shift_to_make_pos);
-		return function (val) {
-		    val = parseFloat(val);
-		    return (Math.log(val + shift_to_make_pos) - log_range_lower) / log_range;
-		};
+			var shift_to_make_pos = Math.abs(range[0]) + 1;
+			var log_range = Math.log(range[1] + shift_to_make_pos) - Math.log(range[0] + shift_to_make_pos);
+			var log_range_lower = Math.log(range[0] + shift_to_make_pos);
+			return function(val) {
+				val = parseFloat(val);
+				return (Math.log(val + shift_to_make_pos) - log_range_lower)/log_range;
+			};
 	    } else {
-		var range_spread = range[1] - range[0];
-		var range_lower = range[0];
-		return function (val) {
-		    val = parseFloat(val);
-		    if (val <= range[0]) {
-			return 0;
-		    } else if (val >= range[1]) {
-			return 1;
-		    } else {
-			return (val - range_lower) / range_spread;
-		    }
-		};
+            return function (val) {
+                var range_spread = range[1] - range[0],
+					range_lower = range[0],
+					range_higher = range[1];
+
+                if (rangeType === rangeTypes.NON_POSITIVE) {
+                    // when data only contains non positive values
+                    return (val - range_higher) / range_spread;
+				} else if (rangeType === rangeTypes.NON_NEGATIVE) {
+                    // when data only contains non negative values
+                    return (val - range_lower) / range_spread;
+				} else if (rangeType === rangeTypes.ALL) {
+                    range_spread = Math.abs(range[0]) > range[1] ? Math.abs(range[0]) : range[1];
+                    return val / range_spread;
+				}
+            };
 	    }
 	};
     }
@@ -517,6 +529,17 @@ var LinearInterpRuleSet = (function () {
 	    ret[1] += ret[1] / 2;
 	}
 	return ret;
+    };
+
+    LinearInterpRuleSet.prototype.getValueRangeType = function () {
+    	var range = this.getEffectiveValueRange();
+        if (range[0] < 0 && range[1] <=0) {
+        	return this.rangeTypes.NON_POSITIVE;
+        } else if (range[0] >= 0 && range[1] > 0) {
+            return this.rangeTypes.NON_NEGATIVE;
+        } else {
+            return this.rangeTypes.ALL;
+        }
     };
 
     LinearInterpRuleSet.prototype.apply = function (data, cell_width, cell_height, out_active_rules) {
@@ -568,7 +591,7 @@ var GradientRuleSet = (function () {
 	if (this.colors.length === 0) {
 	    this.colors.push([0,0,0,1],[255,0,0,1]);
 	}
-	
+
 	this.value_stop_points = params.value_stop_points;
 
 	this.gradient_rule;
@@ -613,7 +636,7 @@ var GradientRuleSet = (function () {
 		var end_color = colors[end_interval_index];
 		return "rgba(" + linInterpColors(interval_t, begin_color, end_color).join(",") + ")";
 	    }
-	    
+
 	};
     }
 
@@ -625,7 +648,7 @@ var GradientRuleSet = (function () {
 	var colorFn = this.makeColorFn(this.colors, interpFn);
 	var value_key = this.value_key;
 	var null_color = this.null_color;
-	
+
 	this.gradient_rule = this.addRule(function (d) {
 	    return d[NA_STRING] !== true;
 	},
@@ -650,40 +673,75 @@ var GradientRuleSet = (function () {
 
 var BarRuleSet = (function () {
     function BarRuleSet(params) {
-	LinearInterpRuleSet.call(this, params);
-	this.bar_rule;
-	this.fill = params.fill || 'rgba(156,123,135,1)';
+		LinearInterpRuleSet.call(this, params);
+		this.fill = params.fill || 'rgba(0,128,0,1)'; // green
+		this.negative_fill = params.negative_fill || 'rgba(255,0,0,1)'; //red
     }
+
     BarRuleSet.prototype = Object.create(LinearInterpRuleSet.prototype);
 
     BarRuleSet.prototype.updateLinearRules = function () {
-	if (typeof this.bar_rule !== "undefined") {
-	    this.removeRule(this.bar_rule);
-	}
-	var interpFn = this.makeInterpFn();
-	var value_key = this.value_key;
-	this.bar_rule = this.addRule(function (d) {
-	    return d[NA_STRING] !== true;
-	},
-		{shapes: [{
-			    type: 'rectangle',
-			    y: function (d) {
-				var t = interpFn(d[value_key]);
-				return (1 - t) * 100 + "%";
-			    },
-			    height: function (d) {
-				var t = interpFn(d[value_key]);
-				return t * 100 + "%";
-			    },
-			    fill: this.fill,
-			}],
-		    exclude_from_legend: false,
-		    legend_config: {'type': 'number', 
-				    'range': this.getEffectiveValueRange(), 
-				    'color': this.fill,
-				    'interpFn': interpFn}
-		});
+        if (typeof this.bar_rule !== "undefined") {
+            this.removeRule(this.bar_rule);
+        }
+        var interpFn = this.makeInterpFn();
+        var value_key = this.value_key;
+        var positive_color = this.fill;
+        var negative_color = this.negative_fill;
+        var yPosFn = this.getYPosPercentagesFn();
+        var cellHeightFn = this.getCellHeightPercentagesFn();
+
+        this.bar_rule = this.addRule(function (d) {
+                return d[NA_STRING] !== true;
+            },
+            {shapes: [{
+                type: 'rectangle',
+                y: function (d) {
+                    var t = interpFn(d[value_key]);
+                    return yPosFn(t);
+                },
+                height: function (d) {
+                    var t = interpFn(d[value_key]);
+                    return cellHeightFn(t);
+                },
+                fill: function (d) {
+					return d[value_key] < 0 ? negative_color : positive_color;
+                }
+            }],
+                exclude_from_legend: false,
+                legend_config: {
+            		'type': 'number',
+                    'range': this.getEffectiveValueRange(),
+					'range_type': this.getValueRangeType(),
+                    'positive_color': positive_color,
+                    'negative_color': negative_color,
+                    'interpFn': interpFn}
+            });
     };
+
+    BarRuleSet.prototype.getYPosPercentagesFn = function () {
+    	return function (t) {
+            if (this.getValueRangeType() === this.rangeTypes.NON_POSITIVE) {
+                return 0 + "%";
+            } else if (this.getValueRangeType() === this.rangeTypes.NON_NEGATIVE) {
+                return (1 - t) * 100 + "%";
+            } else if (this.getValueRangeType() === this.rangeTypes.ALL) {
+                return 50 + "%";
+            }
+		}.bind(this);
+	};
+
+    BarRuleSet.prototype.getCellHeightPercentagesFn = function () {
+    	return function (t) {
+            if (this.getValueRangeType() === this.rangeTypes.NON_POSITIVE) {
+                return -t * 100 + "%";
+            } else if (this.getValueRangeType() === this.rangeTypes.NON_NEGATIVE) {
+                return t * 100 + "%";
+            } else if (this.getValueRangeType() === this.rangeTypes.ALL) {
+                return -t * 50 + "%";
+            }
+		}.bind(this);
+	};
 
     return BarRuleSet;
 })();
@@ -700,12 +758,12 @@ var StackedBarRuleSet = (function() {
 	var fills = params.fills || [];
 	var categories = params.categories || [];
 	var getUnusedColor = makeUniqueColorGetter(fills);
-	
+
 	// Initialize with default values
 	while (fills.length < categories.length) {
 	    fills.push(getUnusedColor());
 	}
-	
+
 	var self = this;
 	for (var i=0; i < categories.length; i++) {
 	    (function(I) {

--- a/src/js/oncoprinttrackoptionsview.js
+++ b/src/js/oncoprinttrackoptionsview.js
@@ -125,7 +125,7 @@ var OncoprintTrackOptionsView = (function () {
 	var $div, $img, $dropdown;
 	var top = model.getZoomedTrackTops(track_id);
 	$div = $('<div>').appendTo(view.$buttons_ctr).css({'position': 'absolute', 'left': '0px', 'top': top + 'px'});
-	$img = $('<img/>').appendTo($div).attr({'src': 'img/menudots.svg', 'width': view.img_size, 'height': view.img_size}).css({'float': 'left', 'cursor': 'pointer', 'border': '1px solid rgba(125,125,125,0)'});
+	$img = $('<img/>').appendTo($div).attr({'src': 'images/menudots.svg', 'width': view.img_size, 'height': view.img_size}).css({'float': 'left', 'cursor': 'pointer', 'border': '1px solid rgba(125,125,125,0)'});
 	$dropdown = $('<ul>').appendTo(view.$dropdown_ctr).css({'position':'absolute', 'width': 120, 'display': 'none', 'list-style-type': 'none', 'padding-left': '6', 'padding-right': '6', 'float': 'right', 'background-color': 'rgb(255,255,255)',
 								'left':'0px', 'top': top + view.img_size + 'px'});
 	view.track_options_$elts[track_id] = {'$div': $div, '$img': $img, '$dropdown': $dropdown};

--- a/src/js/svgfactory.js
+++ b/src/js/svgfactory.js
@@ -96,22 +96,36 @@ module.exports = {
     bgrect: function(width, height, fill) {
 	return makeSVGElement('rect', {'width':width, 'height':height, 'fill':fill});
     },
-    path: function(points, stroke, fill) {
+    path: function(points, stroke, fill, linearGradient) {
 	points = points.map(function(pt) { return pt.join(","); });
 	points[0] = 'M'+points[0];
 	for (var i=1; i<points.length; i++) {
 	    points[i] = 'L'+points[i];
 	}
-	stroke = extractColor(stroke);
-	fill = extractColor(fill);
+
+	if (!linearGradient) {
+        stroke = extractColor(stroke);
+        fill = extractColor(fill);
+	}
+
 	return makeSVGElement('path', {
 	    'd': points.join(" "),
-	    'stroke': stroke.rgb,
-	    'stroke-opacity': stroke.opacity,
-	    'fill': fill.rgb,
-	    'fill-opacity': fill.opacity
+	    'stroke': linearGradient ? 'url(#'+linearGradient.getAttribute('id')+')' : stroke.rgb,
+	    'stroke-opacity': linearGradient ? 0 : stroke.opacity,
+	    'fill': linearGradient ? 'url(#'+linearGradient.getAttribute('id')+')' : fill.rgb,
+	    'fill-opacity': linearGradient ? 1 : fill.opacity
 	});
     },
+    stop: function (offset, stop_color, stop_opacity) {
+		return makeSVGElement('stop', {
+			'offset': offset + '%',
+			'stop-color': stop_color,
+			'stop-opacity': stop_opacity
+		});
+	},
+	linearGradient: function () {
+        return makeSVGElement('linearGradient', {'id': 'linearGradient'+gradientId()});
+	},
     defs: function() {
 	return makeSVGElement('defs');
     },
@@ -125,11 +139,9 @@ module.exports = {
 	});
 	for (var i=0; i<=100; i++) {
 	    var color = extractColor(colorFn(i/100));
-	    gradient.appendChild(makeSVGElement('stop', {
-		'offset': i + '%',
-		'stop-color':color.rgb,
-		'stop-opacity': color.opacity
-	    }));
+	    gradient.appendChild(
+	    	this.stop(i + '%', color.rgb, color.opacity)
+		);
 	}
 	return gradient;
     }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,47 @@
+var Oncoprint = require('./src/js/oncoprint.js');
+
+$(document).ready(function() {
+    window.oncoprint = new Oncoprint('#oncoprint');
+    var data = [];
+    while (data.length < 1000) {
+        // ---
+        // getting random test data from 0 to 10
+        // data.push({'sample':Math.random(), data:Math.random()*10});
+
+        // getting random test data from 10 to 20
+        // data.push({'sample':Math.random(), data:(Math.random()*10) + 10});
+
+        // getting random test data from -10 to 10
+        data.push({'sample':Math.random(), data:(Math.random() * 7500) - 5000});
+
+        // getting random test data from -10 to 0
+        // data.push({'sample':Math.random(), data:(Math.random()*10) - 10});
+
+        // getting random test data from -20 to -10
+        // data.push({'sample':Math.random(), data:(Math.random() * (-20000)) - 1000});
+    }
+    var rule_set_params = {
+        type: 'bar',
+        value_key: 'data',
+        // value_range:[0,10],
+        // value_range:[10,20],
+        // value_range:[-10,10],
+        // value_range:[-10,0],
+        // value_range:[-21000,-1000],
+        legend_label: 'Data',
+        log_value: true
+    };
+    window.oncoprint.addTracks([{'data':data, 'rule_set_params': rule_set_params, 'data_id_key':'sample'},
+        {'data':data, 'rule_set_params': rule_set_params, 'data_id_key':'sample'},
+        {'data':data, 'rule_set_params': rule_set_params, 'data_id_key':'sample'},
+        {'data':data, 'rule_set_params': rule_set_params, 'target_group':1, 'data_id_key':'sample'},
+        {'data':data, 'rule_set_params':rule_set_params, 'target_group':2, 'data_id_key':'sample'}]);
+
+    window.addTracks = function() {
+        var tracks_to_add = [];
+        for (var i=0; i<30; i++) {
+            tracks_to_add.push({'data':data, 'rule_set_params':rule_set_params, 'target_group':3, 'data_id_key':'sample'});
+        }
+        window.oncoprint.addTracks(tracks_to_add);
+    }
+});


### PR DESCRIPTION
This pull request is to add support of negative values when displaying clinical track in the OncoPrint tab. These changes will handle three possibilities:

### Data consists of non negative values
===
<img width="791" alt="screen shot 2017-08-01 at 22 03 41" src="https://user-images.githubusercontent.com/2835281/29035764-1ba8b3e0-7b9d-11e7-9394-301c9179531c.png">


### Data consists of non positive values
===
<img width="791" alt="screen shot 2017-08-01 at 22 04 13" src="https://user-images.githubusercontent.com/2835281/29035801-3bf95974-7b9d-11e7-981c-961bcd76ce01.png">


### Data consists of all type of values
===
<img width="798" alt="screen shot 2017-08-01 at 22 03 14" src="https://user-images.githubusercontent.com/2835281/29035808-43b9fcea-7b9d-11e7-9f72-941de0ebba22.png">

 