### PR TITLE
Port gene set functionality from cBioPortal pull requests

### DIFF
--- a/src/js/oncoprint.js
+++ b/src/js/oncoprint.js
@@ -210,7 +210,7 @@ var Oncoprint = (function () {
 	}*/
 	
 	this.track_options_view = new OncoprintTrackOptionsView($track_options_div,
-								function(track_id) { 
+								function (track_id) {
 								    // move up
 								    var tracks = self.model.getContainingTrackGroup(track_id);
 								    var index = tracks.indexOf(track_id);
@@ -222,7 +222,7 @@ var Oncoprint = (function () {
 									self.moveTrack(track_id, new_previous_track);
 								    }
 								},
-								function(track_id) {
+								function (track_id) {
 								    // move down
 								    var tracks = self.model.getContainingTrackGroup(track_id);
 								    var index = tracks.indexOf(track_id);
@@ -230,8 +230,9 @@ var Oncoprint = (function () {
 									self.moveTrack(track_id, tracks[index+1]);
 								    }
 								},
-								function(track_id) { self.removeTrack(track_id); }, 
-								function(track_id, dir) { self.setTrackSortDirection(track_id, dir); });
+								function (track_id) { self.removeTrack(track_id); },
+								function (track_id, dir) { self.setTrackSortDirection(track_id, dir); },
+								function (track_id) { self.removeExpansionTracksFor(track_id); });
 	this.track_info_view = new OncoprintTrackInfoView($track_info_div);
 								
 	//this.track_info_view = new OncoprintTrackInfoView($track_info_div);
@@ -494,6 +495,28 @@ var Oncoprint = (function () {
     Oncoprint.prototype.removeAllTracks = function() {
 	var track_ids = this.model.getTracks();
 	this.removeTracks(track_ids);
+    }
+
+    Oncoprint.prototype.removeExpansionTracksFor = function (track_id) {
+	// remove all expansion tracks for this track
+	this.removeTracks(this.model.track_expansion_tracks[track_id].slice());
+    }
+
+    Oncoprint.prototype.removeAllExpansionTracksInGroup = function (index) {
+	var tracks_in_group = this.model.getTrackGroups()[index],
+	    expanded_tracks = [],
+	    i;
+	for (i = 0; i < tracks_in_group.length ; i++) {
+	    if (this.model.isTrackExpanded(tracks_in_group[i])) {
+		expanded_tracks.push(tracks_in_group[i]);
+	    }
+	}
+	this.suppressRendering();
+	for (i = 0; i < expanded_tracks.length; i++) {
+	    // assume that the expanded tracks are not themselves removed here
+	    this.removeExpansionTracksFor(expanded_tracks[i]);
+	}
+	this.releaseRendering();
     }
 
     Oncoprint.prototype.setHorzZoomToFit = function(ids) {

--- a/src/js/oncoprintlabelview.js
+++ b/src/js/oncoprintlabelview.js
@@ -19,6 +19,7 @@ var OncoprintLabelView = (function () {
 	this.cell_heights_view_space = {};
 	this.label_middles_view_space = {};
 	this.labels = {};
+	this.label_colors = {};
 	this.track_descriptions = {};
 	this.tracks = [];
 	this.minimum_track_height = Number.POSITIVE_INFINITY;
@@ -164,6 +165,10 @@ var OncoprintLabelView = (function () {
 	view.ctx.fillStyle = 'black';
 	var tracks = view.tracks;
 	for (var i=0; i<tracks.length; i++) {
+	    if (view.label_colors && view.label_colors[tracks[i]]) {
+		//override color, if set:
+		view.ctx.fillStyle = view.label_colors[tracks[i]];
+	    }
 	    view.ctx.fillText(shortenLabelIfNecessary(view, view.labels[tracks[i]]), 0, view.label_middles_view_space[tracks[i]]);
 	}
 	if (view.dragged_label_track_id !== null) {
@@ -281,6 +286,7 @@ var OncoprintLabelView = (function () {
     OncoprintLabelView.prototype.addTracks = function (model, track_ids) {
 	for (var i=0; i<track_ids.length; i++) {
 	    this.labels[track_ids[i]] = model.getTrackLabel(track_ids[i]);
+	    this.label_colors[track_ids[i]] = model.getTrackLabelColor(track_ids[i]);
 	}
 	updateFromModel(this, model);
 	resizeAndClear(this, model);

--- a/src/js/oncoprintlabelview.js
+++ b/src/js/oncoprintlabelview.js
@@ -157,11 +157,11 @@ var OncoprintLabelView = (function () {
 	if (link_url) {
 	    header_contents = (
 		    $('<a target="_blank" rel="noopener noreferrer">')
-		    .attr('href', link_url)
-		    .text(label));
+		    .attr('href', link_url));
 	} else {
-	    header_contents = document.createTextNode(label);
+	    header_contents = $('<span>');
 	}
+	header_contents.append(label.html_content || document.createTextNode(label));
 	return $('<b style="display: block;">').append(header_contents);
     };
     var renderAllLabels = function(view) {

--- a/src/js/oncoprintlabelview.js
+++ b/src/js/oncoprintlabelview.js
@@ -20,6 +20,7 @@ var OncoprintLabelView = (function () {
 	this.label_middles_view_space = {};
 	this.labels = {};
 	this.label_colors = {};
+	this.track_link_urls = {};
 	this.track_descriptions = {};
 	this.tracks = [];
 	this.minimum_track_height = Number.POSITIVE_INFINITY;
@@ -58,12 +59,15 @@ var OncoprintLabelView = (function () {
 		    if (hovered_track !== null) {
 			var $tooltip_div = $('<div>');
 			var offset = view.$canvas.offset();   
-			if (isNecessaryToShortenLabel(view, view.labels[hovered_track])) {
-			    $tooltip_div.append($('<b>'+view.labels[hovered_track]+'</b><br>'));
+			if (isNecessaryToShortenLabel(view, view.labels[hovered_track])
+				|| view.track_link_urls[hovered_track]) {
+			    $tooltip_div.append(formatTooltipHeader(
+				    view.labels[hovered_track],
+				    view.track_link_urls[hovered_track]));
 			}
-			var track_description = view.track_descriptions[hovered_track].replace("<", "&lt;").replace(">", "&gt;");
+			var track_description = view.track_descriptions[hovered_track];
 			if (track_description.length > 0) {
-			    $tooltip_div.append(track_description + "<br>");
+			    $tooltip_div.append($('<div>').text(track_description));
 			}
 			if (model.isTrackInClusteredGroup(hovered_track)) {
                 view.$canvas.css('cursor', 'not-allowed');
@@ -86,7 +90,7 @@ var OncoprintLabelView = (function () {
 		    var previous_track_id = getLabelAboveMouseSpace(view, track_group, evt.offsetY, view.dragged_label_track_id);
 		    stopDragging(view, previous_track_id);
 		}
-		view.tooltip.hide();
+		view.tooltip.hideIfNotAlreadyGoingTo(150);
 	    });
 	})(this);
 	
@@ -147,6 +151,18 @@ var OncoprintLabelView = (function () {
 	} else {
 	    return label;
 	}
+    };
+    var formatTooltipHeader = function (label, link_url) {
+	var header_contents;
+	if (link_url) {
+	    header_contents = (
+		    $('<a target="_blank" rel="noopener noreferrer">')
+		    .attr('href', link_url)
+		    .text(label));
+	} else {
+	    header_contents = document.createTextNode(label);
+	}
+	return $('<b style="display: block;">').append(header_contents);
     };
     var renderAllLabels = function(view) {
 	if (view.rendering_suppressed) {
@@ -287,6 +303,7 @@ var OncoprintLabelView = (function () {
 	for (var i=0; i<track_ids.length; i++) {
 	    this.labels[track_ids[i]] = model.getTrackLabel(track_ids[i]);
 	    this.label_colors[track_ids[i]] = model.getTrackLabelColor(track_ids[i]);
+	    this.track_link_urls[track_ids[i]] = model.getTrackLinkUrl(track_ids[i]);
 	}
 	updateFromModel(this, model);
 	resizeAndClear(this, model);

--- a/src/js/oncoprintlabelview.js
+++ b/src/js/oncoprintlabelview.js
@@ -49,7 +49,8 @@ var OncoprintLabelView = (function () {
 	    view.$canvas.on("mousemove", function(evt) {
 		if (view.dragged_label_track_id !== null) {
 		    var track_group = model.getContainingTrackGroup(view.dragged_label_track_id);
-		    var max_drag_y = view.track_tops[track_group[track_group.length-1]] + model.getTrackHeight(track_group[track_group.length-1]) - view.scroll_y;
+		    var bottommost_track = model.getLastExpansion(track_group[track_group.length - 1]);
+		    var max_drag_y = view.track_tops[bottommost_track] + model.getTrackHeight(bottommost_track) - view.scroll_y;
 		    var min_drag_y = view.track_tops[track_group[0]] - 5 - view.scroll_y;
 		    view.drag_mouse_y = Math.min(evt.pageY - view.$canvas.offset().top, max_drag_y);
 		    view.drag_mouse_y = Math.max(view.drag_mouse_y, min_drag_y);
@@ -192,7 +193,7 @@ var OncoprintLabelView = (function () {
 	    view.ctx.fillText(shortenLabelIfNecessary(view, view.labels[view.dragged_label_track_id]), 0, view.supersampling_ratio*view.drag_mouse_y);
 	    view.ctx.fillStyle = 'rgba(0,0,0,0.15)';
 	    var group = view.model.getContainingTrackGroup(view.dragged_label_track_id);
-	    var label_above_mouse = getLabelAboveMouseSpace(view, group, view.drag_mouse_y, null);
+	    var label_above_mouse = view.model.getLastExpansion(getLabelAboveMouseSpace(view, group, view.drag_mouse_y, null));
 	    var label_below_mouse = getLabelBelowMouseSpace(view, group, view.drag_mouse_y, null);
 	    var rect_y, rect_height;
 	    if (label_above_mouse === view.dragged_label_track_id || label_below_mouse === view.dragged_label_track_id) {
@@ -205,7 +206,7 @@ var OncoprintLabelView = (function () {
 		rect_y = view.cell_tops_view_space[group[0]] - view.ctx.measureText("m").width;
 		rect_height = view.ctx.measureText("m").width;
 	    } else if (label_below_mouse === null) {
-		rect_y = view.cell_tops_view_space[group[group.length-1]] + view.cell_heights_view_space[group[group.length-1]];
+		rect_y = view.cell_tops_view_space[label_above_mouse] + view.cell_heights_view_space[label_above_mouse];
 		rect_height = view.ctx.measureText("m").width;
 	    }
 	    

--- a/src/js/oncoprintmodel.js
+++ b/src/js/oncoprintmodel.js
@@ -132,6 +132,7 @@ var OncoprintModel = (function () {
 	// Track Properties
 	this.track_label = {};
 	this.track_label_color = {};
+	this.track_link_url = {};
 	this.track_description = {};
 	this.cell_height = {};
 	this.track_padding = {};
@@ -707,7 +708,7 @@ var OncoprintModel = (function () {
 	    var params = params_list[i];
 	    addTrack(this, params.track_id, params.target_group, params.track_group_header,
 		    params.cell_height, params.track_padding, params.has_column_spacing,
-		    params.data_id_key, params.tooltipFn,
+		    params.data_id_key, params.tooltipFn, params.link_url,
 		    params.removable, params.removeCallback, params.label, params.description, params.track_info,
 		    params.sortCmpFn, params.sort_direction_changeable, params.init_sort_direction, params.onSortDirectionChange,
 		    params.data, params.rule_set, params.track_label_color);
@@ -717,12 +718,13 @@ var OncoprintModel = (function () {
   
     var addTrack = function (model, track_id, target_group, track_group_header,
 	    cell_height, track_padding, has_column_spacing,
-	    data_id_key, tooltipFn,
+	    data_id_key, tooltipFn, link_url,
 	    removable, removeCallback, label, description, track_info,
 	    sortCmpFn, sort_direction_changeable, init_sort_direction, onSortDirectionChange,
 	    data, rule_set, track_label_color) {
 	model.track_label[track_id] = ifndef(label, "Label");
 	model.track_label_color[track_id] = ifndef(track_label_color, "black");
+	model.track_link_url[track_id] = ifndef(link_url, null);
 	model.track_description[track_id] = ifndef(description, "");
 	model.cell_height[track_id] = ifndef(cell_height, 23);
 	model.track_padding[track_id] = ifndef(track_padding, 5);
@@ -818,6 +820,7 @@ var OncoprintModel = (function () {
 	delete this.track_data[track_id];
 	delete this.track_rule_set_id[track_id];
 	delete this.track_label[track_id];
+	delete this.track_link_url[track_id];
 	delete this.cell_height[track_id];
 	delete this.track_padding[track_id];
 	delete this.track_data_id_key[track_id];
@@ -1031,6 +1034,10 @@ var OncoprintModel = (function () {
     
     OncoprintModel.prototype.getTrackLabelColor = function (track_id) {
 	return this.track_label_color[track_id];
+    }
+    
+    OncoprintModel.prototype.getTrackLinkUrl = function (track_id) {
+	return this.track_link_url[track_id];
     }
     
     OncoprintModel.prototype.getTrackDescription = function(track_id) {

--- a/src/js/oncoprintmodel.js
+++ b/src/js/oncoprintmodel.js
@@ -131,6 +131,7 @@ var OncoprintModel = (function () {
 	
 	// Track Properties
 	this.track_label = {};
+	this.track_label_color = {};
 	this.track_description = {};
 	this.cell_height = {};
 	this.track_padding = {};
@@ -709,7 +710,7 @@ var OncoprintModel = (function () {
 		    params.data_id_key, params.tooltipFn,
 		    params.removable, params.removeCallback, params.label, params.description, params.track_info,
 		    params.sortCmpFn, params.sort_direction_changeable, params.init_sort_direction, params.onSortDirectionChange,
-		    params.data, params.rule_set);
+		    params.data, params.rule_set, params.track_label_color);
 	}
 	this.track_tops.update();
     }
@@ -719,8 +720,9 @@ var OncoprintModel = (function () {
 	    data_id_key, tooltipFn,
 	    removable, removeCallback, label, description, track_info,
 	    sortCmpFn, sort_direction_changeable, init_sort_direction, onSortDirectionChange,
-	    data, rule_set) {
+	    data, rule_set, track_label_color) {
 	model.track_label[track_id] = ifndef(label, "Label");
+	model.track_label_color[track_id] = ifndef(track_label_color, "black");
 	model.track_description[track_id] = ifndef(description, "");
 	model.cell_height[track_id] = ifndef(cell_height, 23);
 	model.track_padding[track_id] = ifndef(track_padding, 5);
@@ -1025,6 +1027,10 @@ var OncoprintModel = (function () {
 
     OncoprintModel.prototype.getTrackLabel = function (track_id) {
 	return this.track_label[track_id];
+    }
+    
+    OncoprintModel.prototype.getTrackLabelColor = function (track_id) {
+	return this.track_label_color[track_id];
     }
     
     OncoprintModel.prototype.getTrackDescription = function(track_id) {

--- a/src/js/oncoprintmodel.js
+++ b/src/js/oncoprintmodel.js
@@ -1,3 +1,4 @@
+/* jshint browserify: true, asi: true */
 var binarysearch = require('./binarysearch.js');
 var hasElementsInInterval = require('./haselementsininterval.js');
 var CachedProperty = require('./CachedProperty.js');
@@ -149,6 +150,11 @@ var OncoprintModel = (function () {
 	this.track_active_rules = {}; // from track id to active rule map (map with rule ids as keys)
 	this.track_info = {};
 	this.track_has_column_spacing = {}; // track id -> boolean
+	this.track_expansion_enabled = {}; // track id -> boolean or undefined
+	this.track_expand_callback = {}; // track id -> function that adds expansion tracks for its track if set
+	this.track_expand_button_getter = {}; // track id -> function from boolean to string if customized
+	this.track_expansion_tracks = {}; // track id -> array of track ids if applicable
+	this.track_expansion_parent = {}; // track id -> track id if applicable
 	
 	// Rule Set Properties
 	this.rule_sets = {}; // map from rule set id to rule set
@@ -711,7 +717,8 @@ var OncoprintModel = (function () {
 		    params.data_id_key, params.tooltipFn, params.link_url,
 		    params.removable, params.removeCallback, params.label, params.description, params.track_info,
 		    params.sortCmpFn, params.sort_direction_changeable, params.init_sort_direction, params.onSortDirectionChange,
-		    params.data, params.rule_set, params.track_label_color);
+		    params.data, params.rule_set, params.track_label_color, params.expansion_of,
+		    params.expandCallback, params.expandButtonTextGetter);
 	}
 	this.track_tops.update();
     }
@@ -721,7 +728,8 @@ var OncoprintModel = (function () {
 	    data_id_key, tooltipFn, link_url,
 	    removable, removeCallback, label, description, track_info,
 	    sortCmpFn, sort_direction_changeable, init_sort_direction, onSortDirectionChange,
-	    data, rule_set, track_label_color) {
+	    data, rule_set, track_label_color, expansion_of, expandCallback,
+	    expandButtonTextGetter) {
 	model.track_label[track_id] = ifndef(label, "Label");
 	model.track_label_color[track_id] = ifndef(track_label_color, "black");
 	model.track_link_url[track_id] = ifndef(link_url, null);
@@ -735,6 +743,24 @@ var OncoprintModel = (function () {
 	});
 	model.track_removable[track_id] = ifndef(removable, false);
 	model.track_remove_callback[track_id] = ifndef(removeCallback, function() {});
+	
+	if (typeof expansion_of !== 'undefined') {
+	    if (!model.track_expansion_tracks.hasOwnProperty(expansion_of)) {
+		model.track_expansion_tracks[expansion_of] = [];
+	    }
+	    if (model.track_expansion_tracks[expansion_of].indexOf(track_id) !== -1) {
+		throw new Error('Illegal state: duplicate expansion track ID');
+	    }
+	    model.track_expansion_parent[track_id] = expansion_of;
+	    model.track_expansion_tracks[expansion_of].push(track_id);
+	}
+	if (typeof expandCallback !== 'undefined') {
+	    model.track_expand_callback[track_id] = expandCallback;
+	    model.track_expansion_enabled[track_id] = true;
+	}
+	if (typeof expandButtonTextGetter !== 'undefined') {
+	    model.track_expand_button_getter[track_id] = expandButtonTextGetter;
+	}
 	
 	model.track_sort_cmp_fn[track_id] = ifndef(sortCmpFn, function () {
 	    return 0;
@@ -775,7 +801,9 @@ var OncoprintModel = (function () {
 	model.setIdOrder(Object.keys(model.present_ids.get()));
     }
 
-    var _getContainingTrackGroup = function (oncoprint_model, track_id, return_reference, return_index) {
+    // get a reference to the array that stores the order of tracks in
+    // the same group
+    var _getMajorTrackGroup = function (oncoprint_model, track_id, return_index) {
 	var group;
 	track_id = parseInt(track_id);
 	var i;
@@ -786,14 +814,26 @@ var OncoprintModel = (function () {
 	    }
 	}
 	if (group) {
-		if (return_index) {
-			return i;
-		} else {
-	    	return (return_reference ? group : group.slice());
-		}
+	    return return_index ? i : group;
 	} else {
 	    return null;
 	}
+    }
+    // get an array listing the track IDs that a track can move around
+    var _getEffectiveTrackGroup = function (oncoprint_model, track_id) {
+	var group,
+	    parent_id = oncoprint_model.track_expansion_parent[track_id];
+	if (parent_id === undefined) {
+	    group = (function(major_group) {
+		return (major_group === null ? null
+			: major_group.filter(function (sibling_id) {
+			    return oncoprint_model.track_expansion_parent[sibling_id] === undefined;
+			}));
+	    })(_getMajorTrackGroup(oncoprint_model, track_id));
+	} else {
+	    group = oncoprint_model.track_expansion_tracks[parent_id];
+	}
+	return group ? group.slice() : null;
     }
 
     var isRuleSetUsed = function(model, rule_set_id) {
@@ -832,12 +872,22 @@ var OncoprintModel = (function () {
 	delete this.track_sort_direction[track_id];
 	delete this.track_info[track_id];
 	delete this.track_has_column_spacing[track_id];
+	delete this.track_expansion_enabled[track_id];
+	delete this.track_expand_callback[track_id];
+	delete this.track_expand_button_getter[track_id];
+	delete this.track_expansion_tracks[track_id];
 
-	var containing_track_group = _getContainingTrackGroup(this, track_id, true);
+	var containing_track_group = _getMajorTrackGroup(this, track_id);
 	if (containing_track_group !== null) {
 	    containing_track_group.splice(
 		    containing_track_group.indexOf(track_id), 1);
 	}
+	// remove listing of the track as an expansion of its parent track
+	var expansion_group = this.track_expansion_tracks[this.track_expansion_parent[track_id]]
+	if (expansion_group) {
+	    expansion_group.splice(expansion_group.indexOf(track_id), 1);
+	}
+	delete this.track_expansion_parent[track_id];
 	this.track_tops.update();
 	this.track_present_ids.update(this, track_id);
 	this.track_id_to_datum.update(this, track_id);
@@ -847,7 +897,7 @@ var OncoprintModel = (function () {
 	if (!rule_set_used) {
 	    removeRuleSet(this, rule_set_id);
 	}
-    }
+    };
     
     OncoprintModel.prototype.getOverlappingCell = function(x,y) {
 	// First, see if it's in a column
@@ -921,11 +971,11 @@ var OncoprintModel = (function () {
     }
     
     OncoprintModel.prototype.getContainingTrackGroup = function (track_id) {
-	return _getContainingTrackGroup(this, track_id, false);
+	return _getEffectiveTrackGroup(this, track_id);
     }
 
     OncoprintModel.prototype.getContainingTrackGroupIndex = function(track_id) {
-    	return _getContainingTrackGroup(this, track_id, false, true);
+    	return _getMajorTrackGroup(this, track_id, true);
 	}
 
     OncoprintModel.prototype.setTrackGroupHeader = function(track_group_id, text) {
@@ -1018,15 +1068,40 @@ var OncoprintModel = (function () {
 	return this.getOncoprintWidth();
     }
     OncoprintModel.prototype.moveTrack = function (track_id, new_previous_track) {
-	var track_group = _getContainingTrackGroup(this, track_id, true);
+
+	function moveContiguousValues(uniqArray, first_value, last_value, new_predecessor) {
+	    var old_start_index = uniqArray.indexOf(first_value),
+		old_end_index = uniqArray.indexOf(last_value);
+	    var values = uniqArray.slice(old_start_index, old_end_index + 1);
+	    uniqArray.splice(old_start_index, values.length);
+	    var new_position = (new_predecessor === null ? 0 : uniqArray.indexOf(new_predecessor)+1);
+	    uniqArray.splice.bind(uniqArray, new_position, 0).apply(null, values);
+	}
+
+	var track_group = _getMajorTrackGroup(this, track_id),
+	    expansion_parent = this.track_expansion_parent[track_id],
+	    flat_previous_track;
+
 	if (track_group !== null) {
-	    track_group.splice(track_group.indexOf(track_id), 1);
-	    var new_position = (new_previous_track === null ? 0 : track_group.indexOf(new_previous_track)+1);
-	    track_group.splice(new_position, 0, track_id);
+	    // if an expansion track moves above all other tracks it can,
+	    // place it directly below its expansion parent
+	    if (expansion_parent !== undefined && new_previous_track === null) {
+		flat_previous_track = expansion_parent;
+	    // otherwise, place the track under (the last expansion track of)
+	    // its sibling
+	    } else {
+		flat_previous_track = this.getLastExpansion(new_previous_track);
+	    }
+	    moveContiguousValues(track_group, track_id, this.getLastExpansion(track_id), flat_previous_track);
+	}
+
+	// keep the order of expansion siblings up-to-date as well
+	if (this.track_expansion_parent[track_id] !== undefined) {
+	    moveContiguousValues(this.track_expansion_tracks[expansion_parent], track_id, track_id, new_previous_track);
 	}
 	
 	this.track_tops.update();
-    }
+    };
 
     OncoprintModel.prototype.getTrackLabel = function (track_id) {
 	return this.track_label[track_id];
@@ -1066,7 +1141,69 @@ var OncoprintModel = (function () {
     OncoprintModel.prototype.isTrackSortDirectionChangeable = function (track_id) {
 	return this.track_sort_direction_changeable[track_id];
     }
+    
+    OncoprintModel.prototype.isTrackExpandable = function (track_id) {
+	// return true if the flag is defined and true
+	return Boolean(this.track_expansion_enabled[track_id]);
+    }
+    
+    OncoprintModel.prototype.expandTrack = function (track_id) {
+	return this.track_expand_callback[track_id](track_id);
+    }
+    
+    OncoprintModel.prototype.disableTrackExpansion = function (track_id) {
+	this.track_expansion_enabled[track_id] = false;
+    }
 
+    OncoprintModel.prototype.enableTrackExpansion = function (track_id) {
+	if (!this.track_expand_callback.hasOwnProperty(track_id)) {
+	    throw new Error("Track '" + track_id +"' has no expandCallback");
+	}
+	this.track_expansion_enabled[track_id] = true;
+    }
+    
+    OncoprintModel.prototype.isTrackExpanded = function (track_id) {
+	return this.track_expansion_tracks.hasOwnProperty(track_id) &&
+		this.track_expansion_tracks[track_id].length > 0;
+    }
+    
+    OncoprintModel.prototype.getExpandButtonText = function (track_id) {
+	var self = this;
+	var getExpandButtonFunction = function (track_id) {
+	    return (self.track_expand_button_getter[track_id] ||
+		    function (is_expanded) {
+			return is_expanded ? 'Expand more' : 'Expand';
+		    });
+	};
+	return getExpandButtonFunction(track_id)(this.isTrackExpanded(track_id));
+    }
+    
+    /**
+     * Checks if one track is the expansion of another
+     *
+     * @param {number} expansion_track_id - the ID of the track to check
+     * @param {number} set_track_id - the ID of the track it may be an expansion of
+     */
+    OncoprintModel.prototype.isExpansionOf = function (expansion_track_id, set_track_id) {
+	return this.track_expansion_tracks.hasOwnProperty(set_track_id) &&
+	    this.track_expansion_tracks[set_track_id].indexOf(expansion_track_id) !== -1;
+    }
+    
+    /**
+     * Finds the bottom-most track in a track's expansion group
+     *
+     * @param track_id - the ID of the track to start from
+     * @returns the ID of its last expansion, or the unchanged param if none
+     */
+    OncoprintModel.prototype.getLastExpansion = function (track_id) {
+	var direct_children = this.track_expansion_tracks[track_id];
+	while (direct_children && direct_children.length) {
+	    track_id = direct_children[direct_children.length - 1];
+	    direct_children = this.track_expansion_tracks[track_id];
+	}
+	return track_id;
+    }
+    
     OncoprintModel.prototype.getRuleSet = function (track_id) {
 	return this.rule_sets[this.track_rule_set_id[track_id]];
     }

--- a/src/js/oncoprintmodel.js
+++ b/src/js/oncoprintmodel.js
@@ -744,16 +744,6 @@ var OncoprintModel = (function () {
 	model.track_removable[track_id] = ifndef(removable, false);
 	model.track_remove_callback[track_id] = ifndef(removeCallback, function() {});
 	
-	if (typeof expansion_of !== 'undefined') {
-	    if (!model.track_expansion_tracks.hasOwnProperty(expansion_of)) {
-		model.track_expansion_tracks[expansion_of] = [];
-	    }
-	    if (model.track_expansion_tracks[expansion_of].indexOf(track_id) !== -1) {
-		throw new Error('Illegal state: duplicate expansion track ID');
-	    }
-	    model.track_expansion_parent[track_id] = expansion_of;
-	    model.track_expansion_tracks[expansion_of].push(track_id);
-	}
 	if (typeof expandCallback !== 'undefined') {
 	    model.track_expand_callback[track_id] = expandCallback;
 	    model.track_expansion_enabled[track_id] = true;
@@ -790,9 +780,24 @@ var OncoprintModel = (function () {
 	if (track_group_header) {
 	    model.track_group_header[target_group] = track_group_header;
 	}
-	model.track_groups[target_group].push(track_id);
-	
-	
+
+	var group_array = model.track_groups[target_group];
+	var target_index = (expansion_of !== undefined
+	    ? group_array.indexOf(model.getLastExpansion(expansion_of)) + 1
+	    : group_array.length
+	);
+	group_array.splice(target_index, 0, track_id);
+
+	if (expansion_of !== undefined) {
+	    if (!model.track_expansion_tracks.hasOwnProperty(expansion_of)) {
+		model.track_expansion_tracks[expansion_of] = [];
+	    }
+	    if (model.track_expansion_tracks[expansion_of].indexOf(track_id) !== -1) {
+		throw new Error('Illegal state: duplicate expansion track ID');
+	    }
+	    model.track_expansion_parent[track_id] = expansion_of;
+	    model.track_expansion_tracks[expansion_of].push(track_id);
+	}
 	
 	model.track_id_to_datum.update(model, track_id);
 	model.track_present_ids.update(model, track_id);

--- a/src/js/oncoprinttrackoptionsview.js
+++ b/src/js/oncoprinttrackoptionsview.js
@@ -5,7 +5,7 @@ var TOGGLE_BTN_OPEN_CLASS = "oncoprintjs__track_options__open";
 var DROPDOWN_CLASS = "oncoprintjs__track_options__dropdown";
 
 var OncoprintTrackOptionsView = (function () {
-    function OncoprintTrackOptionsView($div, moveUpCallback, moveDownCallback, removeCallback, sortChangeCallback) {
+    function OncoprintTrackOptionsView($div, moveUpCallback, moveDownCallback, removeCallback, sortChangeCallback, unexpandCallback) {
 	// removeCallback: function(track_id)
 	var position = $div.css('position');
 	if (position !== 'absolute' && position !== 'relative') {
@@ -16,6 +16,7 @@ var OncoprintTrackOptionsView = (function () {
 	this.moveDownCallback = moveDownCallback;
 	this.removeCallback = removeCallback; // function(track_id) { ... }
 	this.sortChangeCallback = sortChangeCallback; // function(track_id, dir) { ... }
+	this.unexpandCallback = unexpandCallback; // function(track_id)
 
 	this.$div = $div;
 	this.$ctr = $('<div></div>').css({'position': 'absolute', 'overflow-y':'hidden', 'overflow-x':'hidden'}).appendTo(this.$div);
@@ -245,6 +246,29 @@ var OncoprintTrackOptionsView = (function () {
 	    $dropdown.append($sort_inc_li);
 	    $dropdown.append($sort_dec_li);
 	    $dropdown.append($dont_sort_li);
+	}
+	if (model.isTrackExpandable(track_id)) {
+	    $dropdown.append($makeDropdownOption(
+		    model.getExpandButtonText(track_id),
+		    'normal',
+		    false,
+		    function (evt) {
+			evt.stopPropagation();
+			// close the menu to discourage clicking again, as it
+			// may take a moment to finish expanding
+			renderAllOptions(view, model);
+			model.expandTrack(track_id);
+		    }));
+	}
+	if (model.isTrackExpanded(track_id)) {
+	    $dropdown.append($makeDropdownOption(
+		    'Remove expansion',
+		    'normal',
+		    false,
+		    function (evt) {
+			evt.stopPropagation();
+			view.unexpandCallback(track_id);
+		    }));
 	}
     };
 

--- a/test/oncoprint-heatmap.js
+++ b/test/oncoprint-heatmap.js
@@ -1,9 +1,62 @@
 $(document).ready(function() {
 
 var oncoprint = new window.Oncoprint("#oncoprint-heatmap", 800);
-oncoprint.suppressRendering();
+var TRACK_GROUP = 1;
 
 // hm_data is in heatmap-data.js
+
+var current_expansion_tracks = [];
+function makeExpandCallback(gene_id) {
+  return function (parent_track_id) {
+    oncoprint.suppressRendering();
+    try {
+      for (var i = 0; i < 3; i++) {
+        var track_params = {
+            'rule_set_params': {
+              'type': 'gradient',
+              'legend_label': 'Expansion',
+              'value_key': 'vaf',
+              'value_range': [-3, 3],
+              'colors': [[0, 255, 255,1],[0,0,0,1],[255,255,0,1]],
+              'value_stop_points': [-3, 0, 3],
+              'null_color': 'rgba(224,224,224,1)',
+            },
+            'has_column_spacing': true,
+            'track_padding': 5,
+            'label': gene_id + 'abc'[i],
+            'track_label_color': 'teal',
+            'sortCmpFn': function(d1, d2) {return 0;},
+            'target_group': TRACK_GROUP,
+            'expansion_of': parent_track_id,
+            'removable': true,
+            'removeCallback': function (track_id) {
+              current_expansion_tracks.splice(
+                  current_expansion_tracks.indexOf(track_id),
+                  1
+              )
+            }
+        }
+        var track_order_in_group = oncoprint.model.getTrackGroups()[TRACK_GROUP].slice();
+        var preceding_track_index = track_order_in_group.indexOf(oncoprint.model.getLastExpansion(parent_track_id));
+        var new_track_id = oncoprint.addTracks([track_params])[0];
+        if (current_expansion_tracks.length > 0) {
+          oncoprint.shareRuleSet(current_expansion_tracks[0], new_track_id);
+        }
+        current_expansion_tracks.push(new_track_id);
+        track_order_in_group.splice(preceding_track_index + 1, 0, new_track_id);
+        oncoprint.setTrackGroupOrder(TRACK_GROUP, track_order_in_group);
+        var data_record = hm_data.filter(function (record) {
+          return record.gene === gene_id;
+        })[0];
+        oncoprint.setTrackData(new_track_id, data_record.data, 'sample');
+      }
+    } finally {
+      oncoprint.releaseRendering();
+    }
+  }
+}
+
+oncoprint.suppressRendering();
 
 var share_id = null;
 for (var i = 0; i < hm_data.length; i++) {
@@ -21,8 +74,9 @@ for (var i = 0; i < hm_data.length; i++) {
     'track_padding': 5,
     'label': hm_data[i].gene,
     'sortCmpFn': function(d1, d2) {return 0;},
-    'target_group': 1,
-    'removable': true,
+    'target_group': TRACK_GROUP,
+    'expandCallback': makeExpandCallback(hm_data[i].gene),
+    'removable': true
   };
   var new_hm_id = oncoprint.addTracks([track_params])[0];
   hm_data[i].track_id = new_hm_id;

--- a/test/oncoprint-heatmap.js
+++ b/test/oncoprint-heatmap.js
@@ -36,15 +36,11 @@ function makeExpandCallback(gene_id) {
               )
             }
         }
-        var track_order_in_group = oncoprint.model.getTrackGroups()[TRACK_GROUP].slice();
-        var preceding_track_index = track_order_in_group.indexOf(oncoprint.model.getLastExpansion(parent_track_id));
         var new_track_id = oncoprint.addTracks([track_params])[0];
         if (current_expansion_tracks.length > 0) {
           oncoprint.shareRuleSet(current_expansion_tracks[0], new_track_id);
         }
         current_expansion_tracks.push(new_track_id);
-        track_order_in_group.splice(preceding_track_index + 1, 0, new_track_id);
-        oncoprint.setTrackGroupOrder(TRACK_GROUP, track_order_in_group);
         var data_record = hm_data.filter(function (record) {
           return record.gene === gene_id;
         })[0];


### PR DESCRIPTION
This ports the changes made to the Oncoprint rendering code by the various previously reviewed pull requests collected by cBioPortal/cbioportal#3319 to the OncoprintJS repository, as discussed there. The merge commits indicate where the changes have been reviewed in context. One additional commit demonstrates the functionality in the demo/test setup of the OncoprintJS project.

## Screencast ##

![Screencast showcasing the expand button and expansion group behaviour in the demo Oncoprint, with misrendered track option buttons](https://user-images.githubusercontent.com/4929431/32670693-e1b2f680-c644-11e7-8f6c-f9214226545f.gif)

## Structure ##

<details>
<summary>This log shows how the commits in the pull request relate to previous pull requests.</summary>

```
* cc3648d10 Demonstrate expansion API in the test setup
* 69287bde8 Fix track dragging below bottommost expansion
*   b03327408 Port changes from pull request thehyve/cbioportal#21
|\
| * 9e5dd1aeb Keep tracks from moving in/out of expansion groups
| * 2d4888262 Move a track's expansion tracks along with it
|/
*   b308f0ba0 Port changes from pull request thehyve/cbioportal#19
|\
| * 739659e1c Allow HTML versions of track names
| * c424ce59b Allow annotating Oncoprint tracks with a hyperlink
| * 3b55080af Make Oncoprint label view tooltips mouse-navigable
| * 41cb6588b Prevent HTML injection in Oncoprint track tooltips
|/
*   258a7b7e0 Port changes from pull request cBioPortal/cbioportal#2190
|\
| * a0c5334a1 Remove expansion tracks before clustering
| * 615f8cfc9 Add track expansion support to  Oncoprint classes
|/
*   a158948ca Port changes from pull request cBioPortal/cbioportal#2186
|\
| * 7e2453bcb Add gene set score heatmap tracks to the Oncoprint
|/
*
```
</details>
  