### PR TITLE
Fix new APIs as discussed in review of cBioPortal gene set PRs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -94,19 +94,25 @@ declare module "oncoprintjs"
         cell_height?: number;
         track_padding?: number;
         has_column_spacing?: boolean;
-        data_id_key?: string;
-        tooltipFn?:TrackTooltipFn<D>;
+        data_id_key?: keyof D;
+        tooltipFn?: TrackTooltipFn<D>;
         removable?:boolean;
         removeCallback?:(track_id:TrackId)=>void;
-        label?:string;
-        description?:string;
+        label?: string;
+        html_label?: string;
+        label_color?: string;
+        link_url?: string;
+        description?: string;
         track_info?:string;
         sortCmpFn?:TrackSortSpecification<D>;
         sort_direction_changeable?:boolean;
         onSortDirectionChange?:(track_id:TrackId, dir:number)=>void;
         init_sort_direction?:TrackSortDirection;
         data?:D[];
-        rule_set_params?:RuleSetParams;
+        rule_set_params?: RuleSetParams;
+        expansion_of?: TrackId;
+        expandCallback?: (id: TrackId) => void;
+        expandButtonTextGetter?: (is_expanded: boolean) => string;
     };
 
     export default class OncoprintJS<D> {
@@ -122,8 +128,10 @@ declare module "oncoprintjs"
         removeTrack:(track_id:TrackId)=>void;
         removeTracks:(track_ids:TrackId[])=>void;
         getTracks:()=>TrackId[];
-        removeAllTracks:()=>void;
-        setHorzZoomToFit:(ids:string[])=>void;
+        removeAllTracks: () => void;
+        removeExpansionTracksFor: (parent_track: TrackId) => void;
+        removeAllExpansionTracksInGroup: (index: TrackGroupIndex) => void;
+        setHorzZoomToFit: (ids: string[]) => void;
         updateHorzZoomToFitIds:(ids:string[])=>void;
         getMinHorzZoom:()=>number;
         getHorzZoom:()=>number;

--- a/src/js/oncoprintlabelview.js
+++ b/src/js/oncoprintlabelview.js
@@ -20,6 +20,7 @@ var OncoprintLabelView = (function () {
 	this.label_middles_view_space = {};
 	this.labels = {};
 	this.label_colors = {};
+	this.html_labels = {};
 	this.track_link_urls = {};
 	this.track_descriptions = {};
 	this.tracks = [];
@@ -64,6 +65,7 @@ var OncoprintLabelView = (function () {
 				|| view.track_link_urls[hovered_track]) {
 			    $tooltip_div.append(formatTooltipHeader(
 				    view.labels[hovered_track],
+				    view.html_labels[hovered_track],
 				    view.track_link_urls[hovered_track]));
 			}
 			var track_description = view.track_descriptions[hovered_track];
@@ -153,7 +155,7 @@ var OncoprintLabelView = (function () {
 	    return label;
 	}
     };
-    var formatTooltipHeader = function (label, link_url) {
+    var formatTooltipHeader = function (label, html_label, link_url) {
 	var header_contents;
 	if (link_url) {
 	    header_contents = (
@@ -162,7 +164,7 @@ var OncoprintLabelView = (function () {
 	} else {
 	    header_contents = $('<span>');
 	}
-	header_contents.append(label.html_content || document.createTextNode(label));
+	header_contents.append(html_label || document.createTextNode(label));
 	return $('<b style="display: block;">').append(header_contents);
     };
     var renderAllLabels = function(view) {
@@ -304,6 +306,7 @@ var OncoprintLabelView = (function () {
 	for (var i=0; i<track_ids.length; i++) {
 	    this.labels[track_ids[i]] = model.getTrackLabel(track_ids[i]);
 	    this.label_colors[track_ids[i]] = model.getTrackLabelColor(track_ids[i]);
+	    this.html_labels[track_ids[i]] = model.getOptionalHtmlTrackLabel(track_ids[i]);
 	    this.track_link_urls[track_ids[i]] = model.getTrackLinkUrl(track_ids[i]);
 	}
 	updateFromModel(this, model);

--- a/src/js/oncoprintmodel.js
+++ b/src/js/oncoprintmodel.js
@@ -133,6 +133,7 @@ var OncoprintModel = (function () {
 	// Track Properties
 	this.track_label = {};
 	this.track_label_color = {};
+	this.track_html_label = {};
 	this.track_link_url = {};
 	this.track_description = {};
 	this.cell_height = {};
@@ -714,22 +715,24 @@ var OncoprintModel = (function () {
 	    var params = params_list[i];
 	    addTrack(this, params.track_id, params.target_group, params.track_group_header,
 		    params.cell_height, params.track_padding, params.has_column_spacing,
-		    params.data_id_key, params.tooltipFn, params.link_url,
-		    params.removable, params.removeCallback, params.label, params.description, params.track_info,
+		    params.data_id_key, params.tooltipFn, params.link_url, params.removable,
+		    params.removeCallback, params.label, params.description, params.track_info,
 		    params.sortCmpFn, params.sort_direction_changeable, params.init_sort_direction, params.onSortDirectionChange,
-		    params.data, params.rule_set, params.track_label_color, params.expansion_of,
-		    params.expandCallback, params.expandButtonTextGetter);
+		    params.data, params.rule_set, params.track_label_color, params.html_label,
+		    params.expansion_of, params.expandCallback, params.expandButtonTextGetter
+	    );
 	}
 	this.track_tops.update();
     }
   
     var addTrack = function (model, track_id, target_group, track_group_header,
 	    cell_height, track_padding, has_column_spacing,
-	    data_id_key, tooltipFn, link_url,
-	    removable, removeCallback, label, description, track_info,
+	    data_id_key, tooltipFn, link_url, removable,
+	    removeCallback, label, description, track_info,
 	    sortCmpFn, sort_direction_changeable, init_sort_direction, onSortDirectionChange,
-	    data, rule_set, track_label_color, expansion_of, expandCallback,
-	    expandButtonTextGetter) {
+	    data, rule_set, track_label_color, html_label,
+	    expansion_of, expandCallback, expandButtonTextGetter
+    ) {
 	model.track_label[track_id] = ifndef(label, "Label");
 	model.track_label_color[track_id] = ifndef(track_label_color, "black");
 	model.track_link_url[track_id] = ifndef(link_url, null);
@@ -760,9 +763,13 @@ var OncoprintModel = (function () {
 	model.track_sort_direction_change_callback[track_id] = ifndef(onSortDirectionChange, function() {});
 	model.track_data[track_id] = ifndef(data, []);
 	model.track_data_id_key[track_id] = ifndef(data_id_key, 'id');
-	
+
 	model.track_info[track_id] = ifndef(track_info, "");
-	
+
+	if (typeof html_label !== 'undefined') {
+	    model.track_html_label[track_id] = html_label;
+	}
+
 	if (typeof rule_set !== 'undefined') {
 	    model.rule_sets[rule_set.rule_set_id] = rule_set;
 	    model.rule_set_active_rules[rule_set.rule_set_id] = {};
@@ -1114,6 +1121,10 @@ var OncoprintModel = (function () {
     
     OncoprintModel.prototype.getTrackLabelColor = function (track_id) {
 	return this.track_label_color[track_id];
+    }
+    
+    OncoprintModel.prototype.getOptionalHtmlTrackLabel = function (track_id) {
+	return this.track_html_label[track_id];
     }
     
     OncoprintModel.prototype.getTrackLinkUrl = function (track_id) {


### PR DESCRIPTION
- Replace the overcomplicated API for pre-formatted track mouseover labels introduced in commit 6310fa4e508101097affb71ac7fc8b037da170bb by a simple optional track parameter
- Declare types for the track parameters and public methods introduced in PR #34 so that TypeScript can validate that cBioPortal uses these correctly