### PR TITLE
Fix clustering for tracks with expansion tracks

### DIFF
--- a/src/js/oncoprintmodel.js
+++ b/src/js/oncoprintmodel.js
@@ -1263,6 +1263,7 @@ var OncoprintModel = (function () {
 
     OncoprintModel.prototype.clusterTrackGroup = function(track_group_index, clusterValueFn) {
     	// Prepare input
+	var self = this;
 		var def = new $.Deferred();
 		var cluster_input = {};
 
@@ -1287,11 +1288,15 @@ var OncoprintModel = (function () {
 	}
 	if (!Object.keys(cluster_input).length) {
 	    // skip clustering if there's nothing to cluster
-	    return;
+	    return def.resolve().promise();
 	}
 
+	// unset sorting by tracks in this group
+	track_group.forEach(function (track_id) {
+	    self.setTrackSortDirection(track_id, 0, true);
+	});
+
 	//do hierarchical clustering in background:
-	var self = this;
         $.when(clustering.hclusterColumns(cluster_input), clustering.hclusterTracks(cluster_input)).then(
             function (columnClusterOrder, trackClusterOrder) {
 		// set clustered column order
@@ -1431,13 +1436,6 @@ var OncoprintModel = (function () {
     
     OncoprintModel.prototype.setSortConfig = function(params) {
 	this.sort_config = params;
-	if (this.sort_config.type === "cluster") {
-		// if sort config is cluster, do not sort by tracks in that group
-		var trackGroup = this.getTrackGroups()[this.sort_config.track_group_index];
-		for (var i=0; i<trackGroup.length; i++) {
-			this.setTrackSortDirection(trackGroup[i], 0, true);
-		}
-	}
     }
 
     OncoprintModel.prototype.isTrackInClusteredGroup = function(track_id) {

--- a/src/js/oncoprintmodel.js
+++ b/src/js/oncoprintmodel.js
@@ -1284,10 +1284,14 @@ var OncoprintModel = (function () {
 				cluster_input[id] = cluster_input[id] || {};
 				cluster_input[id][track_id] = value;
 			}
-		}
-		//do hierarchical clustering in background:
-		var self = this;
+	}
+	if (!Object.keys(cluster_input).length) {
+	    // skip clustering if there's nothing to cluster
+	    return;
+	}
 
+	//do hierarchical clustering in background:
+	var self = this;
         $.when(clustering.hclusterColumns(cluster_input), clustering.hclusterTracks(cluster_input)).then(
             function (columnClusterOrder, trackClusterOrder) {
 		// set clustered column order


### PR DESCRIPTION
Use only data from root-level, non-expansion tracks in a track group to compute the clustering order, keeping expansions ordered underneath their parent tracks. In addition, avoid error messages in the console when the Oncoprint is told to cluster an empty track group at any point, which may happen in some intermediate states in PR cBioPortal/cbioportal-frontend#981.