### PR TITLE
Bucketsort improvements

### DIFF
--- a/dist/oncoprint.bundle.js
+++ b/dist/oncoprint.bundle.js
@@ -16354,8 +16354,7 @@ var OncoprintModel = (function () {
 			vector: getVector(id)
 		};
 	});
-	var sort_vector_length = track_sort_priority.length*2; // if you inspect getVector above, you'll see theres two entries for each track
-	var order = BucketSort.bucketSort(ids_with_vectors, sort_vector_length, function(d) { return d.vector; });
+	var order = BucketSort.bucketSort(ids_with_vectors, function(d) { return d.vector; });
 	model.setIdOrder(order.map(function(d) { return d.id; }));
     };
     OncoprintModel.prototype.sort = function() {
@@ -16393,8 +16392,7 @@ var OncoprintModel = (function () {
 
 var PrecomputedComparator = (function() {
     function PrecomputedComparator(list, comparator, sort_direction, element_identifier_key) {
-		if (typeof comparator === "object" && comparator.vector_length) {
-			// comparator.vector_length being set implies vector-specification for sort order
+		if (typeof comparator === "object" && comparator.isVector) {
 			initializeVector(this, list, comparator, sort_direction, element_identifier_key);
 		} else {
 			initializeComparator(this, list, comparator, sort_direction, element_identifier_key);
@@ -16456,7 +16454,13 @@ var PrecomputedComparator = (function() {
         		return function(d) { return 0; };
 			} else {
         		return function(d) {
-        			return vec(d).map(function(n) { return n * sort_direction; });
+        			return vec(d).map(function(n) {
+        				if (typeof n === typeof 0) {
+        					return n * sort_direction;
+						} else {
+        					return n;
+						}
+					});
 				}
 			}
         };
@@ -16472,7 +16476,6 @@ var PrecomputedComparator = (function() {
         var compareEquals = _compareEquals ? function(d1, d2) { return _compareEquals(d1.d, d2.d); } : undefined;
         var sorted_list = BucketSort.bucketSort(
         	list_with_vectors,
-			getVector.vector_length,
 			function(d) { return d.preferred_vector; },
 			compareEquals
 		);
@@ -16740,9 +16743,10 @@ module.exports = function (content, url) {
 /* 18 */
 /***/ (function(module, exports) {
 
-function bucketSort(array, vector_length, getVector, compareEquals) {
+var string_type = typeof "";
+
+function bucketSort(array, getVector, compareEquals) {
     // array: an array of data
-    // vector_length: the length of vectors coming out of getVector (must be uniform)
     // getVector: a function that takes an element of array and returns an int vector. defaults to identity
     // compareEquals: an optional standard sort comparator - if specified it is run on the
     //               results of the final buckets before returning
@@ -16753,6 +16757,16 @@ function bucketSort(array, vector_length, getVector, compareEquals) {
 
   var new_sorted_array, new_bucket_ranges, bucket_range, sorted_result;
 
+  // find max length vector, to use as template for vector component types, and whose length will be the sort depth
+  var max_length_vector = [];
+  var proposed_vector;
+  for (var i=0; i<array.length; i++) {
+      proposed_vector = getVector(array[i]);
+      if (proposed_vector.length > max_length_vector.length) {
+          max_length_vector = proposed_vector;
+      }
+  }
+  var vector_length = max_length_vector.length;
   for (var vector_index=0; vector_index<vector_length; vector_index++) {
     new_sorted_array = [];
     new_bucket_ranges = [];
@@ -16761,14 +16775,14 @@ function bucketSort(array, vector_length, getVector, compareEquals) {
       bucket_range = current_bucket_ranges[j];
       sorted_result = bucketSortHelper(
           current_sorted_array,
-          vector_length,
           getVector,
           bucket_range.lower_index_incl,
           bucket_range.upper_index_excl,
-          vector_index
+          vector_index,
+          (typeof max_length_vector[vector_index] === string_type)
       );
-      new_sorted_array = new_sorted_array.concat(sorted_result.sorted_array);
-      new_bucket_ranges = new_bucket_ranges.concat(sorted_result.bucket_ranges);
+      extendArray(new_sorted_array, sorted_result.sorted_array);
+      extendArray(new_bucket_ranges, sorted_result.bucket_ranges);
     }
     current_sorted_array = new_sorted_array;
     current_bucket_ranges = new_bucket_ranges;
@@ -16781,12 +16795,65 @@ function bucketSort(array, vector_length, getVector, compareEquals) {
           bucket_range = current_bucket_ranges[j];
           bucket_elts = current_sorted_array.slice(bucket_range.lower_index_incl, bucket_range.upper_index_excl);
           bucket_elts.sort(compareEquals);
-          new_sorted_array = new_sorted_array.concat(bucket_elts);
+          extendArray(new_sorted_array, bucket_elts);
       }
       current_sorted_array = new_sorted_array;
     }
   return current_sorted_array;
 };
+
+function stringSort(array, getString) {
+    // array: an array of data
+    // getString: a function that takes an element of `array` and returns a string. defaults to identity
+
+    // returns strings sorted in "natural order" (i.e. numbers sorted correctly - P2 comes before P10)
+    getString = getString || function(d) { return d; };
+    // compute string vectors we'll sort with
+    var data = array.map(function(d) {
+        return {
+            d: d,
+            vector: stringToVector(getString(d))
+        };
+    });
+    // sort
+    var sorted = bucketSort(data, function(d) { return d.vector; });
+    // return original passed-in data
+    return sorted.map(function(datum) { return datum.d; });
+}
+
+function stringToVector(string) {
+    var vector = [];
+    var len = string.length;
+    var numberStartIncl = -1;
+    var charCode;
+    for (var i=0; i<len; i++) {
+        charCode = string.charCodeAt(i);
+        if (charCode >=48 && charCode <= 57) {
+            // if character is numeric digit 0-9
+            if (numberStartIncl === -1) {
+                // if we're not in a number yet, start number
+                numberStartIncl = i;
+            }
+            // otherwise, nothing to do
+        } else {
+            // character is not numeric
+            if (numberStartIncl > -1) {
+                // if we're in a number, then we need to add the number to the vector
+                vector.push(parseInt(string.substring(numberStartIncl, i), 10));
+                // and record no longer in a number
+                numberStartIncl = -1;
+            }
+            // add character code to vector
+            vector.push(charCode);
+        }
+    }
+    if (numberStartIncl > -1) {
+        // if we're in a number at the end of the string, add it to vector
+        vector.push(parseInt(string.substring(numberStartIncl), 10));
+        // no need to reset numberStartIncl because the algorithm is done
+    }
+    return vector;
+}
 
 function compareFull(d1, d2, getVector, compareEquals) {
     // utility function - comparator that describes sort order given by bucketSort
@@ -16797,26 +16864,55 @@ function compareFull(d1, d2, getVector, compareEquals) {
     return ret;
 }
 
+function compareVectorElements(elt1, elt2) {
+    if (typeof elt1 === string_type) {
+        return compare(stringToVector(elt1), stringToVector(elt2));
+    } else {
+        return signOfDifference(elt1, elt2);
+    }
+}
+
 function compare(vector1, vector2) {
     // utility function - comparator that describes vector sort order given by bucketSort
-    if (vector1.length !== vector2.length)
-        throw new Error("oncoprintjs:bucketsort:compare vector1.length != vector2.length");
 
     var ret = 0;
     // go left to right, return result of first difference
+    // if one vector is shorter, that one comes first
+    var cmp;
     for (var i=0; i<vector1.length; i++) {
-        if (vector1[i] < vector2[i]) {
-            ret = -1;
-            break;
-        } else if (vector1[i] > vector2[i]) {
+        if (i >= vector2.length) {
+            // if we've gotten here, that means no change up til i, and vector2 is shorter
             ret = 1;
             break;
         }
+        cmp = compareVectorElements(vector1[i], vector2[i]);
+        if (cmp !== 0) {
+            ret = cmp;
+            break;
+        }
+    }
+    if (ret === 0) {
+        if (vector1.length < vector2.length) {
+            // we iterated through vector1, so if we get here and no difference, then if
+            // vector1 is shorter, then it comes first
+            ret = -1;
+        }
+        // theres no way to get here and no difference if vector2 is shorter
     }
     return ret;
 }
 
-function bucketSortHelper(array, vector_length, getVector, sort_range_lower_index_incl, sort_range_upper_index_excl, vector_index) {
+function signOfDifference(k1, k2) {
+    return k1 < k2 ? -1 : (k1 > k2 ? 1 : 0);
+}
+
+function extendArray(target, source) {
+    for (var i=0; i<source.length; i++) {
+        target.push(source[i]);
+    }
+}
+
+function bucketSortHelper(array, getVector, sort_range_lower_index_incl, sort_range_upper_index_excl, vector_index, isStringElt) {
     // returns { sorted_array: d[], bucket_ranges:{lower_index_incl, upper_index_excl}[]}} },
     //      where sorted_array only contains elements from the specified range of
     //      array[sort_range_lower_index_incl:sort_range_upper_index_excl]
@@ -16828,41 +16924,54 @@ function bucketSortHelper(array, vector_length, getVector, sort_range_lower_inde
             bucket_ranges: []
         }
     }
-    if (vector_index >= vector_length) {
-        return {
-            sorted_array:array.slice(sort_range_lower_index_incl, sort_range_upper_index_excl),
-            bucket_ranges:[{lower_index_incl: sort_range_lower_index_incl, upper_index_excl: sort_range_upper_index_excl}]
-        }
-    }
 
-    // courtesy check that vectors are right size - by this point we know array not empty
-    var firstVector = getVector(array[0]);
-    if (firstVector.length !== vector_length) {
-        throw new Error("oncoprintjs:bucketsort:bucketSortHelper getVector result length is unexpected: "+
-                "Expected "+vector_length+" but got "+firstVector.length);
-    }
-    // otherwise, bucket sort the specified range
+    // bucket sort the specified range
     // gather elements into buckets
     var buckets = {};
+    var vector, key;
+    var sortFirst = [];
     for (var i=sort_range_lower_index_incl; i<sort_range_upper_index_excl; i++) {
-      var key = getVector(array[i])[vector_index];
-      buckets[key] = buckets[key] || [];
-      buckets[key].push(array[i]);
+      vector = getVector(array[i]);
+      if (vector.length > vector_index) {
+          key = vector[vector_index];
+          buckets[key] = buckets[key] || [];
+          buckets[key].push(array[i]);
+      } else {
+          // if the vector has no entry at this index, sort earlier, in line w string sorting convention of shorter strings first
+          sortFirst.push(array[i]);
+      }
     }
     // reduce in sorted order
-    var keys = Object.keys(buckets).map(function(key) {
-        return parseFloat(key);
-    });
-    keys.sort(function(k1, k2) { return k1 < k2 ? -1 : (k1 > k2 ? 1 : 0); });
+    var keys = Object.keys(buckets);
+    if (!isStringElt) {
+        // sort numbers
+        for (var i=0; i<keys.length; i++) {
+            keys[i] = parseFloat(keys[i]);
+        }
+        keys.sort(signOfDifference);
+    } else {
+        // sort strings
+        keys = stringSort(keys);
+    }
 
     var sorted_array = [];
     var bucket_ranges = [];
+    var lower_index_incl, upper_index_excl;
+    // add sortFirst
+    if (sortFirst.length) {
+        lower_index_incl = sort_range_lower_index_incl + sorted_array.length;
+        bucket_ranges.push({
+            lower_index_incl: lower_index_incl,
+            upper_index_excl: lower_index_incl + sortFirst.length
+        });
+        extendArray(sorted_array, sortFirst);
+    }
     for (var i=0; i<keys.length; i++) {
       var bucket = buckets[keys[i]];
-      var lower_index_incl = sort_range_lower_index_incl + sorted_array.length;
-      var upper_index_excl = lower_index_incl + bucket.length;
+      lower_index_incl = sort_range_lower_index_incl + sorted_array.length;
+      upper_index_excl = lower_index_incl + bucket.length;
       bucket_ranges.push({lower_index_incl: lower_index_incl, upper_index_excl: upper_index_excl});
-      sorted_array = sorted_array.concat(bucket);
+      extendArray(sorted_array, bucket);
     }
 
     return { sorted_array: sorted_array, bucket_ranges: bucket_ranges };
@@ -16870,9 +16979,11 @@ function bucketSortHelper(array, vector_length, getVector, sort_range_lower_inde
 
 module.exports = {
   bucketSort: bucketSort,
+    stringSort: stringSort,
     compare: compare,
     compareFull: compareFull,
-  __bucketSortHelper: bucketSortHelper
+  __bucketSortHelper: bucketSortHelper,
+    __stringToVector:stringToVector
 };
 
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,16 +18,17 @@ declare module "oncoprintjs"
     export type TrackGroupIndex = number;
     export type TrackSortDirection = 0|1|-1;
     export type TrackSortComparator<D> = (d1:D, d2:D)=>number;//returns (0|1|2|-1|-2); for comparison-based sort, where 2 and -2 mean force to end or beginning (resp) no matter what direction sorted in
-    export type TrackSortVector<D> = (d:D)=>number[]; // maps data to vector used for bucket sort
+    export type TrackSortVector<D> = (d:D)=>(number|string)[]; // maps data to vector used for bucket sort - types of elements in each position must be same, i.e. Kth element must always be a number, or always be a string
     export type TrackTooltipFn<D> = (cell_datum:D)=>HTMLElement|string|any;
     export type TrackSortSpecification<D> = TrackSortComparator<D> | TrackSortVector<D> | {
         mandatory:TrackSortComparator<D>; // specifies the mandatory order for the track
         preferred:TrackSortComparator<D>; // specifies the preferred order for the track (can be overridden by mandatory order of higher track)
+        isVector?:false;
     } | {
         mandatory: TrackSortVector<D>; // specifies the mandatory order for the track
         preferred: TrackSortVector<D>; // specifies the preferred order for the track (can be overridden by mandatory order of higher track)
+        isVector: true;
         compareEquals?:TrackSortComparator<D>; // specifies a comparator to be applied to sort among equal sort vectors in the *preferred* order (optional). eg sort by sample id if all else equal
-        vector_length: number; // the length of the sort vectors
     };
 
     export type RuleSetParams = ICategoricalRuleSetParams |

--- a/src/js/bucketsort.js
+++ b/src/js/bucketsort.js
@@ -1,6 +1,7 @@
-function bucketSort(array, vector_length, getVector, compareEquals) {
+var string_type = typeof "";
+
+function bucketSort(array, getVector, compareEquals) {
     // array: an array of data
-    // vector_length: the length of vectors coming out of getVector (must be uniform)
     // getVector: a function that takes an element of array and returns an int vector. defaults to identity
     // compareEquals: an optional standard sort comparator - if specified it is run on the
     //               results of the final buckets before returning
@@ -11,6 +12,16 @@ function bucketSort(array, vector_length, getVector, compareEquals) {
 
   var new_sorted_array, new_bucket_ranges, bucket_range, sorted_result;
 
+  // find max length vector, to use as template for vector component types, and whose length will be the sort depth
+  var max_length_vector = [];
+  var proposed_vector;
+  for (var i=0; i<array.length; i++) {
+      proposed_vector = getVector(array[i]);
+      if (proposed_vector.length > max_length_vector.length) {
+          max_length_vector = proposed_vector;
+      }
+  }
+  var vector_length = max_length_vector.length;
   for (var vector_index=0; vector_index<vector_length; vector_index++) {
     new_sorted_array = [];
     new_bucket_ranges = [];
@@ -19,14 +30,14 @@ function bucketSort(array, vector_length, getVector, compareEquals) {
       bucket_range = current_bucket_ranges[j];
       sorted_result = bucketSortHelper(
           current_sorted_array,
-          vector_length,
           getVector,
           bucket_range.lower_index_incl,
           bucket_range.upper_index_excl,
-          vector_index
+          vector_index,
+          (typeof max_length_vector[vector_index] === string_type)
       );
-      new_sorted_array = new_sorted_array.concat(sorted_result.sorted_array);
-      new_bucket_ranges = new_bucket_ranges.concat(sorted_result.bucket_ranges);
+      extendArray(new_sorted_array, sorted_result.sorted_array);
+      extendArray(new_bucket_ranges, sorted_result.bucket_ranges);
     }
     current_sorted_array = new_sorted_array;
     current_bucket_ranges = new_bucket_ranges;
@@ -39,12 +50,65 @@ function bucketSort(array, vector_length, getVector, compareEquals) {
           bucket_range = current_bucket_ranges[j];
           bucket_elts = current_sorted_array.slice(bucket_range.lower_index_incl, bucket_range.upper_index_excl);
           bucket_elts.sort(compareEquals);
-          new_sorted_array = new_sorted_array.concat(bucket_elts);
+          extendArray(new_sorted_array, bucket_elts);
       }
       current_sorted_array = new_sorted_array;
     }
   return current_sorted_array;
 };
+
+function stringSort(array, getString) {
+    // array: an array of data
+    // getString: a function that takes an element of `array` and returns a string. defaults to identity
+
+    // returns strings sorted in "natural order" (i.e. numbers sorted correctly - P2 comes before P10)
+    getString = getString || function(d) { return d; };
+    // compute string vectors we'll sort with
+    var data = array.map(function(d) {
+        return {
+            d: d,
+            vector: stringToVector(getString(d))
+        };
+    });
+    // sort
+    var sorted = bucketSort(data, function(d) { return d.vector; });
+    // return original passed-in data
+    return sorted.map(function(datum) { return datum.d; });
+}
+
+function stringToVector(string) {
+    var vector = [];
+    var len = string.length;
+    var numberStartIncl = -1;
+    var charCode;
+    for (var i=0; i<len; i++) {
+        charCode = string.charCodeAt(i);
+        if (charCode >=48 && charCode <= 57) {
+            // if character is numeric digit 0-9
+            if (numberStartIncl === -1) {
+                // if we're not in a number yet, start number
+                numberStartIncl = i;
+            }
+            // otherwise, nothing to do
+        } else {
+            // character is not numeric
+            if (numberStartIncl > -1) {
+                // if we're in a number, then we need to add the number to the vector
+                vector.push(parseInt(string.substring(numberStartIncl, i), 10));
+                // and record no longer in a number
+                numberStartIncl = -1;
+            }
+            // add character code to vector
+            vector.push(charCode);
+        }
+    }
+    if (numberStartIncl > -1) {
+        // if we're in a number at the end of the string, add it to vector
+        vector.push(parseInt(string.substring(numberStartIncl), 10));
+        // no need to reset numberStartIncl because the algorithm is done
+    }
+    return vector;
+}
 
 function compareFull(d1, d2, getVector, compareEquals) {
     // utility function - comparator that describes sort order given by bucketSort
@@ -55,26 +119,55 @@ function compareFull(d1, d2, getVector, compareEquals) {
     return ret;
 }
 
+function compareVectorElements(elt1, elt2) {
+    if (typeof elt1 === string_type) {
+        return compare(stringToVector(elt1), stringToVector(elt2));
+    } else {
+        return signOfDifference(elt1, elt2);
+    }
+}
+
 function compare(vector1, vector2) {
     // utility function - comparator that describes vector sort order given by bucketSort
-    if (vector1.length !== vector2.length)
-        throw new Error("oncoprintjs:bucketsort:compare vector1.length != vector2.length");
 
     var ret = 0;
     // go left to right, return result of first difference
+    // if one vector is shorter, that one comes first
+    var cmp;
     for (var i=0; i<vector1.length; i++) {
-        if (vector1[i] < vector2[i]) {
-            ret = -1;
-            break;
-        } else if (vector1[i] > vector2[i]) {
+        if (i >= vector2.length) {
+            // if we've gotten here, that means no change up til i, and vector2 is shorter
             ret = 1;
             break;
         }
+        cmp = compareVectorElements(vector1[i], vector2[i]);
+        if (cmp !== 0) {
+            ret = cmp;
+            break;
+        }
+    }
+    if (ret === 0) {
+        if (vector1.length < vector2.length) {
+            // we iterated through vector1, so if we get here and no difference, then if
+            // vector1 is shorter, then it comes first
+            ret = -1;
+        }
+        // theres no way to get here and no difference if vector2 is shorter
     }
     return ret;
 }
 
-function bucketSortHelper(array, vector_length, getVector, sort_range_lower_index_incl, sort_range_upper_index_excl, vector_index) {
+function signOfDifference(k1, k2) {
+    return k1 < k2 ? -1 : (k1 > k2 ? 1 : 0);
+}
+
+function extendArray(target, source) {
+    for (var i=0; i<source.length; i++) {
+        target.push(source[i]);
+    }
+}
+
+function bucketSortHelper(array, getVector, sort_range_lower_index_incl, sort_range_upper_index_excl, vector_index, isStringElt) {
     // returns { sorted_array: d[], bucket_ranges:{lower_index_incl, upper_index_excl}[]}} },
     //      where sorted_array only contains elements from the specified range of
     //      array[sort_range_lower_index_incl:sort_range_upper_index_excl]
@@ -86,41 +179,54 @@ function bucketSortHelper(array, vector_length, getVector, sort_range_lower_inde
             bucket_ranges: []
         }
     }
-    if (vector_index >= vector_length) {
-        return {
-            sorted_array:array.slice(sort_range_lower_index_incl, sort_range_upper_index_excl),
-            bucket_ranges:[{lower_index_incl: sort_range_lower_index_incl, upper_index_excl: sort_range_upper_index_excl}]
-        }
-    }
 
-    // courtesy check that vectors are right size - by this point we know array not empty
-    var firstVector = getVector(array[0]);
-    if (firstVector.length !== vector_length) {
-        throw new Error("oncoprintjs:bucketsort:bucketSortHelper getVector result length is unexpected: "+
-                "Expected "+vector_length+" but got "+firstVector.length);
-    }
-    // otherwise, bucket sort the specified range
+    // bucket sort the specified range
     // gather elements into buckets
     var buckets = {};
+    var vector, key;
+    var sortFirst = [];
     for (var i=sort_range_lower_index_incl; i<sort_range_upper_index_excl; i++) {
-      var key = getVector(array[i])[vector_index];
-      buckets[key] = buckets[key] || [];
-      buckets[key].push(array[i]);
+      vector = getVector(array[i]);
+      if (vector.length > vector_index) {
+          key = vector[vector_index];
+          buckets[key] = buckets[key] || [];
+          buckets[key].push(array[i]);
+      } else {
+          // if the vector has no entry at this index, sort earlier, in line w string sorting convention of shorter strings first
+          sortFirst.push(array[i]);
+      }
     }
     // reduce in sorted order
-    var keys = Object.keys(buckets).map(function(key) {
-        return parseFloat(key);
-    });
-    keys.sort(function(k1, k2) { return k1 < k2 ? -1 : (k1 > k2 ? 1 : 0); });
+    var keys = Object.keys(buckets);
+    if (!isStringElt) {
+        // sort numbers
+        for (var i=0; i<keys.length; i++) {
+            keys[i] = parseFloat(keys[i]);
+        }
+        keys.sort(signOfDifference);
+    } else {
+        // sort strings
+        keys = stringSort(keys);
+    }
 
     var sorted_array = [];
     var bucket_ranges = [];
+    var lower_index_incl, upper_index_excl;
+    // add sortFirst
+    if (sortFirst.length) {
+        lower_index_incl = sort_range_lower_index_incl + sorted_array.length;
+        bucket_ranges.push({
+            lower_index_incl: lower_index_incl,
+            upper_index_excl: lower_index_incl + sortFirst.length
+        });
+        extendArray(sorted_array, sortFirst);
+    }
     for (var i=0; i<keys.length; i++) {
       var bucket = buckets[keys[i]];
-      var lower_index_incl = sort_range_lower_index_incl + sorted_array.length;
-      var upper_index_excl = lower_index_incl + bucket.length;
+      lower_index_incl = sort_range_lower_index_incl + sorted_array.length;
+      upper_index_excl = lower_index_incl + bucket.length;
       bucket_ranges.push({lower_index_incl: lower_index_incl, upper_index_excl: upper_index_excl});
-      sorted_array = sorted_array.concat(bucket);
+      extendArray(sorted_array, bucket);
     }
 
     return { sorted_array: sorted_array, bucket_ranges: bucket_ranges };
@@ -128,7 +234,9 @@ function bucketSortHelper(array, vector_length, getVector, sort_range_lower_inde
 
 module.exports = {
   bucketSort: bucketSort,
+    stringSort: stringSort,
     compare: compare,
     compareFull: compareFull,
-  __bucketSortHelper: bucketSortHelper
+  __bucketSortHelper: bucketSortHelper,
+    __stringToVector:stringToVector
 };

--- a/src/js/oncoprintmodel.js
+++ b/src/js/oncoprintmodel.js
@@ -1408,8 +1408,7 @@ var OncoprintModel = (function () {
 			vector: getVector(id)
 		};
 	});
-	var sort_vector_length = track_sort_priority.length*2; // if you inspect getVector above, you'll see theres two entries for each track
-	var order = BucketSort.bucketSort(ids_with_vectors, sort_vector_length, function(d) { return d.vector; });
+	var order = BucketSort.bucketSort(ids_with_vectors, function(d) { return d.vector; });
 	model.setIdOrder(order.map(function(d) { return d.id; }));
     };
     OncoprintModel.prototype.sort = function() {
@@ -1447,8 +1446,7 @@ var OncoprintModel = (function () {
 
 var PrecomputedComparator = (function() {
     function PrecomputedComparator(list, comparator, sort_direction, element_identifier_key) {
-		if (typeof comparator === "object" && comparator.vector_length) {
-			// comparator.vector_length being set implies vector-specification for sort order
+		if (typeof comparator === "object" && comparator.isVector) {
 			initializeVector(this, list, comparator, sort_direction, element_identifier_key);
 		} else {
 			initializeComparator(this, list, comparator, sort_direction, element_identifier_key);
@@ -1510,7 +1508,13 @@ var PrecomputedComparator = (function() {
         		return function(d) { return 0; };
 			} else {
         		return function(d) {
-        			return vec(d).map(function(n) { return n * sort_direction; });
+        			return vec(d).map(function(n) {
+        				if (typeof n === typeof 0) {
+        					return n * sort_direction;
+						} else {
+        					return n;
+						}
+					});
 				}
 			}
         };
@@ -1526,7 +1530,6 @@ var PrecomputedComparator = (function() {
         var compareEquals = _compareEquals ? function(d1, d2) { return _compareEquals(d1.d, d2.d); } : undefined;
         var sorted_list = BucketSort.bucketSort(
         	list_with_vectors,
-			getVector.vector_length,
 			function(d) { return d.preferred_vector; },
 			compareEquals
 		);

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -58,23 +58,23 @@ describe("bucketSort", function() {
     describe("bucketSort", function() {
         it("case: empty input", function() {
             assert.deepEqual(
-                BucketSort.bucketSort([], 3),
+                BucketSort.bucketSort([]),
                 []
             );
         });
         it("case: size 1 vectors", function() {
             assert.deepEqual(
-                BucketSort.bucketSort([[3],[1],[2]], 1),
+                BucketSort.bucketSort([[3],[1],[2]]),
                 [[1],[2],[3]]
             );
         });
         it("case: sorting with infinity", function() {
             assert.deepEqual(
-                BucketSort.bucketSort([[Number.POSITIVE_INFINITY, 0], [0, 1]], 2),
+                BucketSort.bucketSort([[Number.POSITIVE_INFINITY, 0], [0, 1]]),
                 [[0,1],[Number.POSITIVE_INFINITY, 0]]
             );
             assert.deepEqual(
-                BucketSort.bucketSort([[0, 0], [Number.NEGATIVE_INFINITY, 1]], 2),
+                BucketSort.bucketSort([[0, 0], [Number.NEGATIVE_INFINITY, 1]]),
                 [[Number.NEGATIVE_INFINITY,1],[0, 0]]
             );
         });
@@ -85,7 +85,7 @@ describe("bucketSort", function() {
                     [0,0,0,0],
                     [2,2,2,2],
                     [1,1,1,1]
-                ], 4),
+                ]),
                 [
                     [0,0,0,0],
                     [1,1,1,1],
@@ -102,7 +102,7 @@ describe("bucketSort", function() {
                     [-12, 23,-17,15],
                     [-21,6,11,4],
                     [12,22,21,8]
-                ], 4),
+                ]),
                 [
                     [-21,6,11,4],
                     [-12, 23,-17,15],
@@ -119,7 +119,7 @@ describe("bucketSort", function() {
                     [-12, 23,-17,15],
                     [-12,6,11,4],
                     [12,22,21,8]
-                ], 4),
+                ]),
                 [
                     [-12,6,11,4],
                     [-12, 23,-17,15],
@@ -135,13 +135,27 @@ describe("bucketSort", function() {
                     [0, 23,-17,15],
                     [0,6,11,4],
                     [0,22,21,8]
-                ], 4),
+                ]),
                 [
                     [0,1,-8,-24],
                     [0,6,11,4],
                     [0,10,-11,5],
                     [0,22,21,8],
                     [0, 23,-17,15]
+                ]
+            );
+            assert.deepEqual(
+                BucketSort.bucketSort([
+                    [0,10,-11,5],
+                    [0,10],
+                    [0],
+                    [0,10,-11]
+                ]),
+                [
+                    [0],
+                    [0,10],
+                    [0,10,-11],
+                    [0,10,-11,5]
                 ]
             );
         });
@@ -151,7 +165,7 @@ describe("bucketSort", function() {
                         {sample:"D", vector:[13,8]},
                         {sample:"A", vector:[13,10]},
                         {sample:"C", vector:[12,10]}
-                ], 2, function(d) { return d.vector; }, function(d1, d2) { return d1.sample.localeCompare(d2.sample); }),
+                ], function(d) { return d.vector; }, function(d1, d2) { return d1.sample.localeCompare(d2.sample); }),
                 [
                     {sample:"C", vector:[12,10]},
                     {sample:"D", vector:[13,8]},
@@ -164,7 +178,7 @@ describe("bucketSort", function() {
                     {sample:"D", vector:[13,10]},
                     {sample:"A", vector:[13,10]},
                     {sample:"C", vector:[12,10]}
-                ], 2, function(d) { return d.vector; }, function(d1, d2) { return d1.sample.localeCompare(d2.sample); }),
+                ], function(d) { return d.vector; }, function(d1, d2) { return d1.sample.localeCompare(d2.sample); }),
                 [
                     {sample:"C", vector:[12,10]},
                     {sample:"A", vector:[13,10]},
@@ -184,7 +198,8 @@ describe("bucketSort", function() {
 
             function generateVector(size) {
                 var ret = [];
-                for (var i=0; i<size; i++) {
+                var vectorSize = size+Math.round(Math.random()*4);
+                for (var i=0; i<vectorSize; i++) {
                     ret.push(randInt(3));
                 }
                 return ret;
@@ -197,7 +212,7 @@ describe("bucketSort", function() {
                 for (var i=0; i<100; i++) {
                     vectors.push(generateVector(size));
                 }
-                var sorted = BucketSort.bucketSort(vectors, size);
+                var sorted = BucketSort.bucketSort(vectors);
                 vectors.sort(BucketSort.compare); // sort using equivalent comparator - resultant order should be same
                 assert.deepEqual(sorted, vectors, "randomized test: vector size "+size);
             }
@@ -214,7 +229,8 @@ describe("bucketSort", function() {
 
             function generateVector(size) {
                 var ret = [];
-                for (var i=0; i<size; i++) {
+                var vectorSize = size+Math.round(Math.random()*4);
+                for (var i=0; i<vectorSize; i++) {
                     ret.push(randInt(3));
                 }
                 return ret;
@@ -239,17 +255,169 @@ describe("bucketSort", function() {
                     name = names.splice(Math.floor(Math.random()*names.length), 1)[0];
                     data.push({name:name, vector:vector});
                 }
-                var sorted = BucketSort.bucketSort(data, size, getVector, compareEquals);
+                var sorted = BucketSort.bucketSort(data, getVector, compareEquals);
                 data.sort(function(d1, d2) { return BucketSort.compareFull(d1, d2, getVector, compareEquals); })// sort using equivalent comparator - resultant order should be same
                 assert.deepEqual(sorted, data, "randomized test: vector size "+size);
             }
+        });
+        it("case: randomized tests, with strings", function() {
+            var names = [];
+            for (var i=0; i<100; i++) {
+                names.push("TCGA-"+(i<10 ? "0" : "")+(i<100 ? "0" : "") + i);
+            }
+
+            function randInt(magnitude) {
+                var ret = Math.round(Math.random()*magnitude - Math.random()*magnitude);
+                if (ret === 0) {
+                    // to deal w issues w negative zero
+                    ret = 0;
+                }
+                return ret;
+            }
+
+            function generateVector(size) {
+                var ret = [];
+                var vectorSize = size+Math.round(Math.random()*4);
+                for (var i=0; i<vectorSize; i++) {
+                    if (i % 2) {
+                        ret.push(randInt(3));
+                    } else {
+                        ret.push(Math.random() < 0.5 ? names[Math.floor(Math.random()*names.length)] : "");
+                    }
+                }
+                return ret;
+            }
+
+            var vectors;
+
+            for (var size=0; size<20; size++) {
+                vectors = [];
+                for (var i=0; i<100; i++) {
+                    vectors.push(generateVector(size));
+                }
+                var sorted = BucketSort.bucketSort(vectors);
+                vectors.sort(BucketSort.compare); // sort using equivalent comparator - resultant order should be same
+                assert.deepEqual(sorted, vectors, "randomized test: vector size "+size);
+            }
+        });
+    });
+    describe("stringToVector", function() {
+        it("creates the right vectors", function() {
+            assert.deepEqual(
+                BucketSort.__stringToVector(""), []
+            );
+            assert.deepEqual(
+                BucketSort.__stringToVector("a"), [97]
+            );
+            assert.deepEqual(
+                BucketSort.__stringToVector("abc"), [97, 98, 99]
+            );
+            assert.deepEqual(
+                BucketSort.__stringToVector("abc123abc456c"), [97, 98, 99, 123, 97, 98, 99, 456, 99]
+            );
+            assert.deepEqual(
+                BucketSort.__stringToVector("abc123abc456"), [97, 98, 99, 123, 97, 98, 99, 456]
+            );
+            assert.deepEqual(
+                BucketSort.__stringToVector("000"), [0]
+            );
+            assert.deepEqual(
+                BucketSort.__stringToVector("1"), [1]
+            );
+        });
+    });
+    describe("stringSort", function() {
+        it("sorts a list in right order", function(){
+            assert.deepEqual(BucketSort.stringSort([
+                "A20",
+                "P20",
+                "P04",
+                "P2",
+                "P13",
+                "ABCDE"
+            ]),[
+                "A20",
+                "ABCDE",
+                "P2",
+                "P04",
+                "P13",
+                "P20"
+            ]);
+        })
+        it("sorts four tcga ids in right order", function() {
+            assert.deepEqual(BucketSort.stringSort(
+                ["TCGA-AA-A01I", "TCGA-AG-3599", "TCGA-AG-3605", "TCGA-AA-3556"]),
+                ["TCGA-AA-A01I", "TCGA-AA-3556", "TCGA-AG-3599", "TCGA-AG-3605"]
+            );
+        });
+        it("sorts a list of tcga ids in right order", function() {
+            assert.deepEqual(BucketSort.stringSort(["TCGA-AG-3605","TCGA-AA-3680","TCGA-AA-3520","TCGA-AA-3854","TCGA-AA-3818","TCGA-AG-3575","TCGA-AA-3522","TCGA-AA-3814","TCGA-AA-3986","TCGA-AA-3696","TCGA-AA-A00Q","TCGA-AA-A00K","TCGA-AA-3561","TCGA-AF-2692","TCGA-AG-3901","TCGA-AA-3556","TCGA-AG-3580","TCGA-AA-3695","TCGA-AA-3930","TCGA-AG-3902","TCGA-AG-3727","TCGA-AA-A029","TCGA-A6-2683","TCGA-AG-3599","TCGA-AA-A01K","TCGA-AG-3878","TCGA-AA-3994","TCGA-AA-3979","TCGA-AG-3887","TCGA-AA-A01G","TCGA-AA-3560","TCGA-AA-3842","TCGA-AA-3837","TCGA-AG-3586","TCGA-AA-A01F","TCGA-AA-3870","TCGA-AA-3521","TCGA-AA-3673","TCGA-AA-A01I","TCGA-AF-2689","TCGA-AA-A02W","TCGA-AA-3681","TCGA-AG-3896","TCGA-AA-3851","TCGA-AA-3548","TCGA-AA-3852","TCGA-AA-3530","TCGA-AA-3939","TCGA-AG-3594","TCGA-AG-3909","TCGA-AA-3532","TCGA-AG-3581","TCGA-AG-3726","TCGA-AG-3611","TCGA-AA-3848","TCGA-AG-3583","TCGA-AG-3602"]),
+                [
+                    "TCGA-A6-2683",
+                    "TCGA-AA-A00K",
+                    "TCGA-AA-A00Q",
+                    "TCGA-AA-A01F",
+                    "TCGA-AA-A01G",
+                    "TCGA-AA-A01I",
+                    "TCGA-AA-A01K",
+                    "TCGA-AA-A02W",
+                    "TCGA-AA-A029",
+                    "TCGA-AA-3520",
+                    "TCGA-AA-3521",
+                    "TCGA-AA-3522",
+                    "TCGA-AA-3530",
+                    "TCGA-AA-3532",
+                    "TCGA-AA-3548",
+                    "TCGA-AA-3556",
+                    "TCGA-AA-3560",
+                    "TCGA-AA-3561",
+                    "TCGA-AA-3673",
+                    "TCGA-AA-3680",
+                    "TCGA-AA-3681",
+                    "TCGA-AA-3695",
+                    "TCGA-AA-3696",
+                    "TCGA-AA-3814",
+                    "TCGA-AA-3818",
+                    "TCGA-AA-3837",
+                    "TCGA-AA-3842",
+                    "TCGA-AA-3848",
+                    "TCGA-AA-3851",
+                    "TCGA-AA-3852",
+                    "TCGA-AA-3854",
+                    "TCGA-AA-3870",
+                    "TCGA-AA-3930",
+                    "TCGA-AA-3939",
+                    "TCGA-AA-3979",
+                    "TCGA-AA-3986",
+                    "TCGA-AA-3994",
+                    "TCGA-AF-2689",
+                    "TCGA-AF-2692",
+                    "TCGA-AG-3575",
+                    "TCGA-AG-3580",
+                    "TCGA-AG-3581",
+                    "TCGA-AG-3583",
+                    "TCGA-AG-3586",
+                    "TCGA-AG-3594",
+                    "TCGA-AG-3599",
+                    "TCGA-AG-3602",
+                    "TCGA-AG-3605",
+                    "TCGA-AG-3611",
+                    "TCGA-AG-3726",
+                    "TCGA-AG-3727",
+                    "TCGA-AG-3878",
+                    "TCGA-AG-3887",
+                    "TCGA-AG-3896",
+                    "TCGA-AG-3901",
+                    "TCGA-AG-3902",
+                    "TCGA-AG-3909"
+                ]);
         });
     });
     describe("__bucketSortHelper", function() {
         it("case: size 1 vector", function() {
             assert.deepEqual(
                 BucketSort.__bucketSortHelper(
-                    [[3],[1],[2]], 1, function(x) { return x; }, 0, 3, 0
+                    [[3],[1],[2]], function(x) { return x; }, 0, 3, 0, false
                 ),
                 {
                     sorted_array: [[1],[2],[3]],


### PR DESCRIPTION
- Remove call dependence on given vector_length, use inferred maximum vector length
- Implement natural string sort, so vectors with string components now supported
- Optimize sorting by using repeated array.push instead of concat, reduces garbage collection
