### PR TITLE
Make svg factory encode colors in fill and fill-opacity, since Batik …

### DIFF
--- a/dist/oncoprint.bundle.js
+++ b/dist/oncoprint.bundle.js
@@ -11249,13 +11249,16 @@ module.exports = {
 	return shapeToSVG(oncoprint_shape_computed_params, offset_x, offset_y);
     },
     polygon: function(points, fill) {
-	return makeSVGElement('polygon', {'points': points, 'fill':fill});
+    	fill = extractColor(fill);
+	return makeSVGElement('polygon', {'points': points, 'fill':fill.rgb, 'fill-opacity':fill.opacity});
     },
     rect: function(x,y,width,height,fill) {
-	return makeSVGElement('rect', {'x':x, 'y':y, 'width':width, 'height':height, 'fill':fill});
+    	fill = extractColor(fill);
+	return makeSVGElement('rect', {'x':x, 'y':y, 'width':width, 'height':height, 'fill':fill.rgb, 'fill-opacity':fill.opacity});
     },
     bgrect: function(width, height, fill) {
-	return makeSVGElement('rect', {'width':width, 'height':height, 'fill':fill});
+    	fill = extractColor(fill);
+	return makeSVGElement('rect', {'width':width, 'height':height, 'fill':fill.rgb, 'fill-opacity':fill.opacity});
     },
     path: function(points, stroke, fill, linearGradient) {
 	points = points.map(function(pt) { return pt.join(","); });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,7 @@
 {
   "name": "oncoprintjs",
-  "version": "v1.0.0",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "JSONStream": {
       "version": "1.3.1",

--- a/src/js/svgfactory.js
+++ b/src/js/svgfactory.js
@@ -88,13 +88,16 @@ module.exports = {
 	return shapeToSVG(oncoprint_shape_computed_params, offset_x, offset_y);
     },
     polygon: function(points, fill) {
-	return makeSVGElement('polygon', {'points': points, 'fill':fill});
+    	fill = extractColor(fill);
+	return makeSVGElement('polygon', {'points': points, 'fill':fill.rgb, 'fill-opacity':fill.opacity});
     },
     rect: function(x,y,width,height,fill) {
-	return makeSVGElement('rect', {'x':x, 'y':y, 'width':width, 'height':height, 'fill':fill});
+    	fill = extractColor(fill);
+	return makeSVGElement('rect', {'x':x, 'y':y, 'width':width, 'height':height, 'fill':fill.rgb, 'fill-opacity':fill.opacity});
     },
     bgrect: function(width, height, fill) {
-	return makeSVGElement('rect', {'width':width, 'height':height, 'fill':fill});
+    	fill = extractColor(fill);
+	return makeSVGElement('rect', {'width':width, 'height':height, 'fill':fill.rgb, 'fill-opacity':fill.opacity});
     },
     path: function(points, stroke, fill, linearGradient) {
 	points = points.map(function(pt) { return pt.join(","); });


### PR DESCRIPTION
…svg to pdf doesnt support rgba

Signed-off-by: Abeshouse, Adam A./Sloan Kettering Institute <abeshoua@mskcc.org>