### PR TITLE
Expose methods to toggle expandability of a track

### DIFF
--- a/dist/oncoprint.bundle.js
+++ b/dist/oncoprint.bundle.js
@@ -14308,6 +14308,14 @@ var Oncoprint = (function () {
 	this.removeTracks(this.model.track_expansion_tracks[track_id].slice());
     }
 
+    Oncoprint.prototype.disableTrackExpansion = function (track_id) {
+	this.model.disableTrackExpansion(track_id);
+    }
+
+    Oncoprint.prototype.enableTrackExpansion = function (track_id) {
+	this.model.enableTrackExpansion(track_id);
+    }
+
     Oncoprint.prototype.removeAllExpansionTracksInGroup = function (index) {
 	var tracks_in_group = this.model.getTrackGroups()[index],
 	    expanded_tracks = [],

--- a/index.d.ts
+++ b/index.d.ts
@@ -140,6 +140,8 @@ declare module "oncoprintjs"
         getTracks:()=>TrackId[];
         removeAllTracks: () => void;
         removeExpansionTracksFor: (parent_track: TrackId) => void;
+        disableTrackExpansion: (track_id: TrackId) => void;
+        enableTrackExpansion: (track_id: TrackId) => void;
         removeAllExpansionTracksInGroup: (index: TrackGroupIndex) => void;
         setHorzZoomToFit: (ids: string[]) => void;
         updateHorzZoomToFitIds:(ids:string[])=>void;

--- a/src/js/oncoprint.js
+++ b/src/js/oncoprint.js
@@ -549,6 +549,14 @@ var Oncoprint = (function () {
 	this.removeTracks(this.model.track_expansion_tracks[track_id].slice());
     }
 
+    Oncoprint.prototype.disableTrackExpansion = function (track_id) {
+	this.model.disableTrackExpansion(track_id);
+    }
+
+    Oncoprint.prototype.enableTrackExpansion = function (track_id) {
+	this.model.enableTrackExpansion(track_id);
+    }
+
     Oncoprint.prototype.removeAllExpansionTracksInGroup = function (index) {
 	var tracks_in_group = this.model.getTrackGroups()[index],
 	    expanded_tracks = [],


### PR DESCRIPTION
I had already implemented the functionality these methods provide, but
never exposed them to TypeScript as gene set functionality did not turn
out to need them. Exposing them now, as the ‘merged track’ feature does.