### PR TITLE
Fix heatmap bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/oncoprint.bundle.js",
   "scripts": {
     "build": "rm -rf ./dist/* && webpack",
+    "build-dev": "yarn build --env.DEV=true",
     "test": "jest",
     "test:watch": "npm run test -- --watch"
   },


### PR DESCRIPTION
To reproduce:
(1) https://ec2-18-157-159-210.eu-central-1.compute.amazonaws.com/results/oncoprint?Action=Submit&RPPA_SCORE_THRESHOLD=2.0&Z_SCORE_THRESHOLD=2.0&cancer_study_list=gbm_tcga&case_set_id=gbm_tcga_cnaseq&data_priority=0&gene_list=TP53&geneset_list=VERHAAK_GLIOBLASTOMA_CLASSICAL&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=gbm_tcga_gistic&genetic_profile_ids_PROFILE_GENESET_SCORE=gbm_tcga_gsva_scores&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=gbm_tcga_mutations&oncoprint_cluster_profile=gbm_tcga_mrna_U133_Zscores&oncoprint_sortby=cluster&profileFilter=0&tab_index=tab_visualize&heatmap_track_groups=gbm_tcga_mrna_U133_Zscores%2CTP53

(2) Remove heatmap group `mRNA Expression z-Scores (U133 microarray only)` using the track group menu dropdown

(3) Add TP53 in `mRNA Expression z-Scores (U133 microarray only)` back to the oncoprint.