### PR TITLE
New oncoprint property to configure tracks that are shown by default (oncoprintjs)

### DIFF
--- a/src/js/oncoprintmodel.ts
+++ b/src/js/oncoprintmodel.ts
@@ -87,6 +87,7 @@ export type UserTrackSpec<D> = {
     custom_track_options?:CustomTrackOption[];
     $track_info_tooltip_elt?:JQuery;
     track_can_show_gaps?:boolean;
+    init_show_gaps?:boolean
 };
 export type LibraryTrackSpec<D> = UserTrackSpec<D> & { rule_set:RuleSet, track_id:TrackId};
 export type TrackOverlappingCells = {
@@ -1153,7 +1154,7 @@ export default class OncoprintModel {
         }
 
         this.track_can_show_gaps[track_id] = ifndef(params.track_can_show_gaps, false);
-        this.track_show_gaps[track_id] = false;
+        this.track_show_gaps[track_id] = (params.init_show_gaps === true) ? true : false;
 
         this.track_sort_cmp_fn[track_id] = params.sortCmpFn;
 

--- a/src/js/oncoprintmodel.ts
+++ b/src/js/oncoprintmodel.ts
@@ -87,7 +87,7 @@ export type UserTrackSpec<D> = {
     custom_track_options?:CustomTrackOption[];
     $track_info_tooltip_elt?:JQuery;
     track_can_show_gaps?:boolean;
-    init_show_gaps?:boolean
+    show_gaps_on_init?:boolean
 };
 export type LibraryTrackSpec<D> = UserTrackSpec<D> & { rule_set:RuleSet, track_id:TrackId};
 export type TrackOverlappingCells = {
@@ -1154,7 +1154,7 @@ export default class OncoprintModel {
         }
 
         this.track_can_show_gaps[track_id] = ifndef(params.track_can_show_gaps, false);
-        this.track_show_gaps[track_id] = (params.init_show_gaps === true) ? true : false;
+        this.track_show_gaps[track_id] = ifndef(params.show_gaps_on_init, false);
 
         this.track_sort_cmp_fn[track_id] = params.sortCmpFn;
 


### PR DESCRIPTION
Change necessary for https://github.com/cBioPortal/cbioportal-frontend/pull/4152

Added a new value for the initial gaps value (enabled/disabled) for the clinical tracks.